### PR TITLE
sort by content

### DIFF
--- a/src/classic/clvm_tools/clvmc.rs
+++ b/src/classic/clvm_tools/clvmc.rs
@@ -53,8 +53,7 @@ pub fn detect_include_directive(allocator: &mut Allocator, sexp: NodePtr, name: 
                         match (allocator.sexp(e[0]), allocator.sexp(e[1])) {
                             (SExp::Atom(inc), SExp::Atom(aname)) => {
                                 if allocator.buf(&inc) == "include".as_bytes().to_vec()
-                                    && allocator.buf(&aname)
-                                        == name.as_bytes().to_vec()
+                                    && allocator.buf(&aname) == name.as_bytes().to_vec()
                                 {
                                     return true;
                                 }

--- a/src/classic/clvm_tools/clvmc.rs
+++ b/src/classic/clvm_tools/clvmc.rs
@@ -30,14 +30,14 @@ use crate::compiler::comptypes::CompileErr;
 use crate::compiler::comptypes::CompilerOpts;
 use crate::compiler::runtypes::RunFailure;
 
-pub fn detect_modern(allocator: &mut Allocator, sexp: NodePtr) -> bool {
+pub fn detect_include_directive(allocator: &mut Allocator, sexp: NodePtr, name: &String) -> bool {
     match proper_list(allocator, sexp, true) {
         None => {
             return false;
         }
         Some(l) => {
             for elt in l.iter() {
-                if detect_modern(allocator, *elt) {
+                if detect_include_directive(allocator, *elt, name) {
                     return true;
                 }
 
@@ -51,10 +51,10 @@ pub fn detect_modern(allocator: &mut Allocator, sexp: NodePtr) -> bool {
                         }
 
                         match (allocator.sexp(e[0]), allocator.sexp(e[1])) {
-                            (SExp::Atom(inc), SExp::Atom(name)) => {
+                            (SExp::Atom(inc), SExp::Atom(aname)) => {
                                 if allocator.buf(&inc) == "include".as_bytes().to_vec()
-                                    && allocator.buf(&name)
-                                        == "*standard-cl-21*".as_bytes().to_vec()
+                                    && allocator.buf(&aname)
+                                        == name.as_bytes().to_vec()
                                 {
                                     return true;
                                 }
@@ -70,6 +70,11 @@ pub fn detect_modern(allocator: &mut Allocator, sexp: NodePtr) -> bool {
     }
 
     return false;
+}
+
+// Improve this in case other include directives need detection here.
+pub fn detect_modern(allocator: &mut Allocator, sexp: NodePtr) -> bool {
+    return detect_include_directive(allocator, sexp, &"*standard-cl-21*".to_string());
 }
 
 fn compile_clvm_text(

--- a/src/classic/clvm_tools/cmds.rs
+++ b/src/classic/clvm_tools/cmds.rs
@@ -1113,6 +1113,7 @@ pub fn launch_tool(
                 _ => false,
             })
             .unwrap_or_else(|| false);
+
         let runner = Rc::new(DefaultProgramRunner::new());
         let use_filename = input_file.unwrap_or_else(|| "*command*".to_string());
         let opts = Rc::new(DefaultCompilerOpts::new(&use_filename)).set_optimize(do_optimize);

--- a/src/classic/clvm_tools/stages/stage_2/module.rs
+++ b/src/classic/clvm_tools/stages/stage_2/module.rs
@@ -17,19 +17,18 @@ use crate::classic::clvm_tools::NodePath::NodePath;
 
 #[derive(Clone, Debug, PartialEq, Hash, Eq)]
 pub enum IncludeDirective {
-    TreeSortByHash
+    TreeSortByHash,
 }
 
 lazy_static! {
     pub static ref MAIN_NAME: String = {
         return "".to_string();
     };
-
     pub static ref KNOWN_INCLUDE_DIRECTIVES: HashMap<Vec<u8>, IncludeDirective> = {
         let mut hs = HashMap::new();
         hs.insert(
             "*tree-sort-by-content*".as_bytes().to_vec(),
-            IncludeDirective::TreeSortByHash
+            IncludeDirective::TreeSortByHash,
         );
         hs
     };
@@ -168,17 +167,18 @@ fn build_used_constants_names(
     }
 
     if directives.contains(&IncludeDirective::TreeSortByHash) {
-        let mut hash_and_name_list: Vec<HashAndName> =
-            used_name_list.iter().map(|name| {
-                let hash = functions.get(name).map(|body| {
-                    sha256tree(allocator, *body).data().clone()
-                }).unwrap_or_else(|| Vec::new()); // Non functions don't count.
+        let mut hash_and_name_list: Vec<HashAndName> = used_name_list
+            .iter()
+            .map(|name| {
+                let hash = functions
+                    .get(name)
+                    .map(|body| sha256tree(allocator, *body).data().clone())
+                    .unwrap_or_else(|| Vec::new()); // Non functions don't count.
                 HashAndName(hash, name.clone())
-            }).collect();
+            })
+            .collect();
         hash_and_name_list.sort();
-        used_name_list = hash_and_name_list.iter().map(|hn| {
-            hn.1.clone()
-        }).collect();
+        used_name_list = hash_and_name_list.iter().map(|hn| hn.1.clone()).collect();
     } else {
         used_name_list.sort();
     }
@@ -201,10 +201,10 @@ fn parse_include(
             match KNOWN_INCLUDE_DIRECTIVES.get(name_vec) {
                 Some(directive) => {
                     return Ok(Some(directive.clone()));
-                },
+                }
                 _ => {}
             }
-        },
+        }
         _ => {}
     }
 

--- a/src/classic/clvm_tools/stages/stage_2/module.rs
+++ b/src/classic/clvm_tools/stages/stage_2/module.rs
@@ -195,8 +195,8 @@ fn parse_include(
     // Short circuit include directive.
     match allocator.sexp(name) {
         SExp::Atom(nbuf) => {
-            let name_vec = allocator.buf(&nbuf).clone();
-            match KNOWN_INCLUDE_DIRECTIVES.get(name_vec) {
+            let name_vec = allocator.buf(&nbuf).to_vec();
+            match KNOWN_INCLUDE_DIRECTIVES.get(&name_vec) {
                 Some(directive) => {
                     return Ok(Some(directive.clone()));
                 }

--- a/src/compiler/codegen.rs
+++ b/src/compiler/codegen.rs
@@ -972,7 +972,9 @@ fn process_helper_let_bindings(
 fn sort_by_content(program: &CompileForm) -> bool {
     let want_name = "*tree-sort-by-content*".as_bytes().to_vec();
     for h in program.helpers.iter() {
-        if h.name() == want_name { return true; }
+        if h.name() == want_name {
+            return true;
+        }
     }
     false
 }
@@ -1000,7 +1002,7 @@ fn start_codegen(opts: Rc<dyn CompilerOpts>, comp: CompileForm) -> PrimaryCodege
                 .collect();
 
             if do_sort_by_content {
-                live_helpers.sort_by(|a,b| {
+                live_helpers.sort_by(|a, b| {
                     let arc = a.body().to_sexp();
                     let brc = b.body().to_sexp();
                     arc.cmp(brc.borrow())

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -142,6 +142,11 @@ impl CompilerOpts for DefaultCompilerOpts {
                 (defconstant *chialisp-version* 21)
             )"};
             return Ok((filename, content.to_string()));
+        } else if filename == "*tree-sort-by-content*" {
+            let content = indoc! {"(
+                (defconstant *tree-sort-by-content* 1)
+            )"};
+            return Ok((filename, content.to_string()));
         }
 
         for dir in self.include_dirs.iter() {

--- a/src/compiler/comptypes.rs
+++ b/src/compiler/comptypes.rs
@@ -212,6 +212,14 @@ impl HelperForm {
         }
     }
 
+    pub fn body(&self) -> Rc<BodyForm> {
+        match self {
+            HelperForm::Defconstant(_, _, b) => b.clone(),
+            HelperForm::Defmacro(_, _, _, b) => b.exp.clone(),
+            HelperForm::Defun(_, _, _, _, b) => b.clone(),
+        }
+    }
+
     pub fn to_sexp(&self) -> Rc<SExp> {
         match self {
             HelperForm::Defconstant(loc, name, body) => Rc::new(list_to_cons(

--- a/src/compiler/frontend.rs
+++ b/src/compiler/frontend.rs
@@ -596,6 +596,13 @@ fn frontend_start(
     }
 }
 
+fn is_defconstant(h: &HelperForm) -> bool {
+    match h {
+        HelperForm::Defconstant(_,_,_) => true,
+        _ => false
+    }
+}
+
 pub fn frontend(
     opts: Rc<dyn CompilerOpts>,
     pre_forms: Vec<Rc<SExp>>,
@@ -632,7 +639,7 @@ pub fn frontend(
 
     let mut live_helpers = Vec::new();
     for h in our_mod.helpers {
-        if helper_names.contains(&h.name()) {
+        if helper_names.contains(&h.name()) || is_defconstant(&h) {
             live_helpers.push(h);
         }
     }

--- a/src/compiler/frontend.rs
+++ b/src/compiler/frontend.rs
@@ -598,8 +598,8 @@ fn frontend_start(
 
 fn is_defconstant(h: &HelperForm) -> bool {
     match h {
-        HelperForm::Defconstant(_,_,_) => true,
-        _ => false
+        HelperForm::Defconstant(_, _, _) => true,
+        _ => false,
     }
 }
 

--- a/src/compiler/sexp.rs
+++ b/src/compiler/sexp.rs
@@ -64,34 +64,34 @@ impl PartialOrd for SExp {
         match (self, other) {
             (SExp::Nil(_), _) => Some(Ordering::Less),
             (_, SExp::Nil(_)) => Some(Ordering::Greater),
-            (SExp::Atom(_,_), SExp::Cons(_,_,_)) => Some(Ordering::Less),
-            (SExp::Integer(_,_), SExp::Cons(_,_,_)) => Some(Ordering::Less),
-            (SExp::QuotedString(_,_,_), SExp::Cons(_,_,_)) => Some(Ordering::Less),
-            (SExp::Cons(_,_,_), SExp::Atom(_,_)) => Some(Ordering::Greater),
-            (SExp::Cons(_,_,_), SExp::Integer(_,_)) => Some(Ordering::Greater),
-            (SExp::Cons(_,_,_), SExp::QuotedString(_,_,_)) => Some(Ordering::Greater),
-            (SExp::Cons(_,a,b), SExp::Cons(_,c,d)) => {
-                match a.partial_cmp(c) {
-                    Some(Ordering::Greater) => Some(Ordering::Greater),
-                    Some(Ordering::Less) => Some(Ordering::Less),
-                    _ => b.partial_cmp(d)
-                }
+            (SExp::Atom(_, _), SExp::Cons(_, _, _)) => Some(Ordering::Less),
+            (SExp::Integer(_, _), SExp::Cons(_, _, _)) => Some(Ordering::Less),
+            (SExp::QuotedString(_, _, _), SExp::Cons(_, _, _)) => Some(Ordering::Less),
+            (SExp::Cons(_, _, _), SExp::Atom(_, _)) => Some(Ordering::Greater),
+            (SExp::Cons(_, _, _), SExp::Integer(_, _)) => Some(Ordering::Greater),
+            (SExp::Cons(_, _, _), SExp::QuotedString(_, _, _)) => Some(Ordering::Greater),
+            (SExp::Cons(_, a, b), SExp::Cons(_, c, d)) => match a.partial_cmp(c) {
+                Some(Ordering::Greater) => Some(Ordering::Greater),
+                Some(Ordering::Less) => Some(Ordering::Less),
+                _ => b.partial_cmp(d),
             },
-            (SExp::Integer(_,a), SExp::Integer(_,b)) => {
-                a.partial_cmp(b)
-            },
+            (SExp::Integer(_, a), SExp::Integer(_, b)) => a.partial_cmp(b),
             (a, b) => {
                 let avec = match a {
                     SExp::Integer(_, a) => u8_from_number(a.clone()),
                     SExp::Atom(_, v) => v.clone(),
                     SExp::QuotedString(_, _, v) => v.clone(),
-                    _ => { panic!("Should not be possible"); }
+                    _ => {
+                        panic!("Should not be possible");
+                    }
                 };
                 let bvec = match b {
                     SExp::Integer(_, b) => u8_from_number(b.clone()),
                     SExp::Atom(_, v) => v.clone(),
                     SExp::QuotedString(_, _, v) => v.clone(),
-                    _ => { panic!("Should not be possible"); }
+                    _ => {
+                        panic!("Should not be possible");
+                    }
                 };
                 avec.partial_cmp(&bvec)
             }

--- a/src/tests/classic/run.rs
+++ b/src/tests/classic/run.rs
@@ -125,7 +125,8 @@ fn run_sort_by_name() {
             "(mod (Z) (defun B (X) (+ X 1)) (defun A (X) (* X 2)) (A (B Z)))".to_string()
         ))
         .trim(),
-        "(a (q 2 4 (c 2 (c (a 6 (c 2 (c 5 ()))) ()))) (c (q (* 5 (q . 2)) 16 5 (q . 1)) 1))".to_string()
+        "(a (q 2 4 (c 2 (c (a 6 (c 2 (c 5 ()))) ()))) (c (q (* 5 (q . 2)) 16 5 (q . 1)) 1))"
+            .to_string()
     );
     assert_eq!(
         do_basic_run(&vec!(

--- a/src/tests/classic/run.rs
+++ b/src/tests/classic/run.rs
@@ -116,3 +116,23 @@ fn brun_constant_test() {
         "(q . 3)".to_string()
     );
 }
+
+#[test]
+fn run_sort_by_name() {
+    assert_eq!(
+        do_basic_run(&vec!(
+            "run".to_string(),
+            "(mod (Z) (defun B (X) (+ X 1)) (defun A (X) (* X 2)) (A (B Z)))".to_string()
+        ))
+        .trim(),
+        "(a (q 2 4 (c 2 (c (a 6 (c 2 (c 5 ()))) ()))) (c (q (* 5 (q . 2)) 16 5 (q . 1)) 1))".to_string()
+    );
+    assert_eq!(
+        do_basic_run(&vec!(
+            "run".to_string(),
+            "(mod (Z) (include *tree-sort-by-content*) (defun B (X) (+ X 1)) (defun A (X) (* X 2)) (A (B Z)))".to_string()
+        ))
+        .trim(),
+        "(a (q 2 6 (c 2 (c (a 4 (c 2 (c 5 ()))) ()))) (c (q (+ 5 (q . 1)) 18 5 (q . 2)) 1))".to_string()
+    );
+}

--- a/src/tests/compiler/compiler.rs
+++ b/src/tests/compiler/compiler.rs
@@ -438,7 +438,7 @@ fn inline_compile_test() {
         "}
         .to_string(),
     )
-    .unwrap();
+        .unwrap();
     assert_eq!(result, "(2 (1 16 5 (1 . 1)) (4 (1) 1))".to_string());
 }
 
@@ -476,4 +476,36 @@ fn cant_redefine_defun_with_defun() {
         ));
         assert!(result.is_err());
     }
+}
+
+#[test]
+fn sort_order_by_content() {
+    let result = compile_string(
+        &indoc! {"
+        (mod (Z)
+          (include *standard-cl-21*)
+          (include *tree-sort-by-content*)
+
+          (defun B (X) (+ X 1))
+          (defun A (X) (* X 2))
+          (A (B Z)))
+        "}
+        .to_string(),
+    )
+        .unwrap();
+    assert_eq!(result, "(2 (1 2 4 (4 2 (4 (2 6 (4 2 (4 5 ()))) ()))) (4 (1 (2 (1 18 5 (1 . 2)) 1) 2 (1 16 5 (1 . 1)) 1) 1))".to_string());
+
+    let result = compile_string(
+        &indoc! {"
+        (mod (Z)
+          (include *standard-cl-21*)
+
+          (defun B (X) (+ X 1))
+          (defun A (X) (* X 2))
+          (A (B Z)))
+        "}
+        .to_string(),
+    )
+        .unwrap();
+    assert_eq!(result, "(2 (1 2 6 (4 2 (4 (2 4 (4 2 (4 5 ()))) ()))) (4 (1 (2 (1 16 5 (1 . 1)) 1) 2 (1 18 5 (1 . 2)) 1) 1))".to_string());
 }

--- a/src/tests/compiler/compiler.rs
+++ b/src/tests/compiler/compiler.rs
@@ -438,7 +438,7 @@ fn inline_compile_test() {
         "}
         .to_string(),
     )
-        .unwrap();
+    .unwrap();
     assert_eq!(result, "(2 (1 16 5 (1 . 1)) (4 (1) 1))".to_string());
 }
 
@@ -492,7 +492,7 @@ fn sort_order_by_content() {
         "}
         .to_string(),
     )
-        .unwrap();
+    .unwrap();
     assert_eq!(result, "(2 (1 2 4 (4 2 (4 (2 6 (4 2 (4 5 ()))) ()))) (4 (1 (2 (1 18 5 (1 . 2)) 1) 2 (1 16 5 (1 . 1)) 1) 1))".to_string());
 
     let result = compile_string(
@@ -506,6 +506,6 @@ fn sort_order_by_content() {
         "}
         .to_string(),
     )
-        .unwrap();
+    .unwrap();
     assert_eq!(result, "(2 (1 2 6 (4 2 (4 (2 4 (4 2 (4 5 ()))) ()))) (4 (1 (2 (1 16 5 (1 . 1)) 1) 2 (1 18 5 (1 . 2)) 1) 1))".to_string());
 }


### PR DESCRIPTION
allow (include *tree-sort-by-content*) to enable sorting the functions in the environment by their content instead of their names in all compiler versions.