### PR TITLE
20220524 fix fe opt

### DIFF
--- a/src/compiler/codegen.rs
+++ b/src/compiler/codegen.rs
@@ -987,7 +987,8 @@ fn start_codegen(
                 let updated_opts = opts
                     .set_compiler(use_compiler.clone())
                     .set_in_defun(false)
-                    .set_stdenv(false);
+                    .set_stdenv(false)
+                    .set_frontend_opt(false);
 
                 updated_opts
                     .compile_program(

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -16,7 +16,7 @@ use crate::compiler::codegen::codegen;
 use crate::compiler::comptypes::{
     BodyForm, CompileErr, CompileForm, CompilerOpts, HelperForm, PrimaryCodegen,
 };
-use crate::compiler::evaluate::{Evaluator, build_reflex_captures};
+use crate::compiler::evaluate::{build_reflex_captures, Evaluator};
 use crate::compiler::frontend::frontend;
 use crate::compiler::prims;
 use crate::compiler::runtypes::RunFailure;
@@ -126,13 +126,8 @@ fn fe_opt(
             HelperForm::Defun(loc, name, inline, args, body) => {
                 let mut env = HashMap::new();
                 build_reflex_captures(&mut env, args.clone());
-                let body_rc = evaluator.shrink_bodyform(
-                    allocator,
-                    args.clone(),
-                    &env,
-                    body.clone(),
-                    true,
-                )?;
+                let body_rc =
+                    evaluator.shrink_bodyform(allocator, args.clone(), &env, body.clone(), true)?;
                 let new_helper = HelperForm::Defun(
                     loc.clone(),
                     name.clone(),

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -16,7 +16,7 @@ use crate::compiler::codegen::codegen;
 use crate::compiler::comptypes::{
     BodyForm, CompileErr, CompileForm, CompilerOpts, HelperForm, PrimaryCodegen,
 };
-use crate::compiler::evaluate::Evaluator;
+use crate::compiler::evaluate::{Evaluator, build_reflex_captures};
 use crate::compiler::frontend::frontend;
 use crate::compiler::prims;
 use crate::compiler::runtypes::RunFailure;
@@ -124,10 +124,12 @@ fn fe_opt(
     for h in compiler_helpers.iter() {
         match h {
             HelperForm::Defun(loc, name, inline, args, body) => {
+                let mut env = HashMap::new();
+                build_reflex_captures(&mut env, args.clone());
                 let body_rc = evaluator.shrink_bodyform(
                     allocator,
-                    Rc::new(SExp::Nil(compileform.args.loc())),
-                    &HashMap::new(),
+                    args.clone(),
+                    &env,
                     body.clone(),
                     true,
                 )?;

--- a/src/compiler/evaluate.rs
+++ b/src/compiler/evaluate.rs
@@ -477,7 +477,6 @@ impl Evaluator {
                     // Build SExp arguments for external call or
                     // return the unevaluated chunk with minimized
                     // arguments.
-                    panic!("foo");
                     Err(CompileErr(
                         l.clone(),
                         format!(

--- a/src/compiler/evaluate.rs
+++ b/src/compiler/evaluate.rs
@@ -357,6 +357,7 @@ impl Evaluator {
             self.expand_macro(allocator, l.clone(), program.clone(), macro_args)?;
 
         let input_sexp = dequote(call_loc.clone(), macro_expansion)?;
+
         let frontend_macro_input = Rc::new(SExp::Cons(
             l.clone(),
             Rc::new(SExp::atom_from_string(l.clone(), &"mod".to_string())),
@@ -476,6 +477,7 @@ impl Evaluator {
                     // Build SExp arguments for external call or
                     // return the unevaluated chunk with minimized
                     // arguments.
+                    panic!("foo");
                     Err(CompileErr(
                         l.clone(),
                         format!(

--- a/src/compiler/evaluate.rs
+++ b/src/compiler/evaluate.rs
@@ -315,8 +315,8 @@ fn synthesize_args(
 
 fn reflex_capture(name: &Vec<u8>, capture: Rc<BodyForm>) -> bool {
     match capture.borrow() {
-        BodyForm::Value(SExp::Atom(_,n)) => n == name,
-        _ => false
+        BodyForm::Value(SExp::Atom(_, n)) => n == name,
+        _ => false,
     }
 }
 
@@ -551,19 +551,17 @@ impl Evaluator {
                     only_inline,
                 )
             }
-            None => {
-                self.invoke_primitive(
-                    allocator,
-                    l.clone(),
-                    call_name,
-                    parts,
-                    body,
-                    prog_args,
-                    arguments_to_convert,
-                    env,
+            None => self.invoke_primitive(
+                allocator,
+                l.clone(),
+                call_name,
+                parts,
+                body,
+                prog_args,
+                arguments_to_convert,
+                env,
                 only_inline,
-                )
-            }
+            ),
         }
     }
 
@@ -789,10 +787,11 @@ impl Evaluator {
         // Com takes place in the current environment.
         // We can only reduce com if all bindings are
         // primitive.
-        let updated_opts = self.opts.
-            set_stdenv(!in_defun).
-            set_in_defun(in_defun).
-            set_frontend_opt(false);
+        let updated_opts = self
+            .opts
+            .set_stdenv(!in_defun)
+            .set_in_defun(in_defun)
+            .set_frontend_opt(false);
 
         let com_result = updated_opts.compile_program(
             allocator,

--- a/src/compiler/evaluate.rs
+++ b/src/compiler/evaluate.rs
@@ -313,6 +313,13 @@ fn synthesize_args(
     }
 }
 
+fn reflex_capture(name: &Vec<u8>, capture: Rc<BodyForm>) -> bool {
+    match capture.borrow() {
+        BodyForm::Value(SExp::Atom(_,n)) => n == name,
+        _ => false
+    }
+}
+
 impl Evaluator {
     pub fn new(
         opts: Rc<dyn CompilerOpts>,
@@ -542,17 +549,19 @@ impl Evaluator {
                     only_inline,
                 )
             }
-            None => self.invoke_primitive(
-                allocator,
-                l.clone(),
-                call_name,
-                parts,
-                body,
-                prog_args,
-                arguments_to_convert,
-                env,
+            None => {
+                self.invoke_primitive(
+                    allocator,
+                    l.clone(),
+                    call_name,
+                    parts,
+                    body,
+                    prog_args,
+                    arguments_to_convert,
+                    env,
                 only_inline,
-            ),
+                )
+            }
         }
     }
 
@@ -620,13 +629,17 @@ impl Evaluator {
                 } else {
                     env.get(name)
                         .map(|x| {
-                            self.shrink_bodyform(
-                                allocator,
-                                prog_args.clone(),
-                                env,
-                                x.clone(),
-                                only_inline,
-                            )
+                            if reflex_capture(name, x.clone()) {
+                                Ok(x.clone())
+                            } else {
+                                self.shrink_bodyform(
+                                    allocator,
+                                    prog_args.clone(),
+                                    env,
+                                    x.clone(),
+                                    only_inline,
+                                )
+                            }
                         })
                         .unwrap_or_else(|| {
                             self.get_constant(name)
@@ -774,7 +787,10 @@ impl Evaluator {
         // Com takes place in the current environment.
         // We can only reduce com if all bindings are
         // primitive.
-        let updated_opts = self.opts.set_stdenv(!in_defun).set_in_defun(in_defun);
+        let updated_opts = self.opts.
+            set_stdenv(!in_defun).
+            set_in_defun(in_defun).
+            set_frontend_opt(false);
 
         let com_result = updated_opts.compile_program(
             allocator,

--- a/src/tests/compiler/compiler.rs
+++ b/src/tests/compiler/compiler.rs
@@ -229,7 +229,7 @@ fn run_test_6() {
 
 #[test]
 fn run_test_6_opt() {
-    // run_test_6_maybe_opt(true);
+    run_test_6_maybe_opt(true);
 }
 
 fn run_test_7_maybe_opt(opt: bool) {

--- a/src/tests/compiler/compiler.rs
+++ b/src/tests/compiler/compiler.rs
@@ -597,3 +597,37 @@ fn cant_redefine_defun_with_defun() {
         assert!(result.is_err());
     }
 }
+
+fn test_collatz_maybe_opt(opt: bool) {
+    let result = run_string_maybe_opt(
+        &indoc! {"
+            (mod (A)
+             (include *standard-cl-22*)
+             (defun-inline odd (X) (logand X 1))
+             (defun collatz (N X)
+              (if (= X 1)
+               N
+               (let ((incN (+ N 1)))
+                (if (odd X)
+                 (collatz incN (+ 1 (* 3 X)))
+                 (collatz incN (/ X 2))
+                )
+               )
+              )
+             )
+             (collatz 0 A)
+            )
+        "}.to_string(),
+        &"(4)".to_string(),
+        opt
+    ).unwrap();
+    assert_eq!(result.to_string(), "(q . 2)");
+}
+
+fn test_collatz() {
+    test_collatz_maybe_opt(false);
+}
+
+fn test_collatz_opt() {
+    test_collatz_maybe_opt(true);
+}

--- a/src/tests/compiler/compiler.rs
+++ b/src/tests/compiler/compiler.rs
@@ -173,7 +173,7 @@ fn run_test_3() {
 
 #[test]
 fn run_test_3_opt() {
-    // run_test_3_maybe_opt(true);
+    run_test_3_maybe_opt(true);
 }
 
 fn run_test_4_maybe_opt(opt: bool) {

--- a/src/tests/compiler/compiler.rs
+++ b/src/tests/compiler/compiler.rs
@@ -193,7 +193,7 @@ fn run_test_4() {
 
 #[test]
 fn run_test_4_opt() {
-    // run_test_4_maybe_opt(true);
+    run_test_4_maybe_opt(true);
 }
 
 fn run_test_5_maybe_opt(opt: bool) {

--- a/src/tests/compiler/compiler.rs
+++ b/src/tests/compiler/compiler.rs
@@ -617,10 +617,12 @@ fn test_collatz_maybe_opt(opt: bool) {
              )
              (collatz 0 A)
             )
-        "}.to_string(),
+        "}
+        .to_string(),
         &"(4)".to_string(),
-        opt
-    ).unwrap();
+        opt,
+    )
+    .unwrap();
     assert_eq!(result.to_string(), "(q . 2)");
 }
 

--- a/src/tests/compiler/compiler.rs
+++ b/src/tests/compiler/compiler.rs
@@ -209,7 +209,7 @@ fn run_test_5() {
 
 #[test]
 fn run_test_5_opt() {
-    // run_test_5_maybe_opt(true);
+    run_test_5_maybe_opt(true);
 }
 
 fn run_test_6_maybe_opt(opt: bool) {
@@ -252,7 +252,7 @@ fn run_test_7() {
 
 #[test]
 fn run_test_7_opt() {
-    // run_test_7_maybe_opt(true);
+    run_test_7_maybe_opt(true);
 }
 
 fn run_test_8_maybe_opt(opt: bool) {

--- a/src/tests/compiler/repl.rs
+++ b/src/tests/compiler/repl.rs
@@ -157,7 +157,9 @@ fn test_collatz() {
             "    )",
             "  )",
             "(collatz 0 3)"
-        ]).unwrap().unwrap(),
+        ])
+        .unwrap()
+        .unwrap(),
         "(q . 7)"
     );
 }

--- a/src/tests/compiler/repl.rs
+++ b/src/tests/compiler/repl.rs
@@ -139,3 +139,25 @@ fn test_last_of_pwcoin_2() {
         "(q (51 3735928559 1))"
     );
 }
+
+#[test]
+fn test_collatz() {
+    assert_eq!(
+        test_repl_outcome(vec![
+            "(defun-inline odd (X) (logand X 1))",
+            "(defun collatz (N X)",
+            "  (if (= X 1)",
+            "    N",
+            "    (let ((incN (+ N 1)))",
+            "      (if (odd X)",
+            "        (collatz incN (+ 1 (* 3 X)))",
+            "        (collatz incN (/ X 2))",
+            "        )",
+            "      )",
+            "    )",
+            "  )",
+            "(collatz 0 3)"
+        ]).unwrap().unwrap(),
+        "(q . 7)"
+    );
+}


### PR DESCRIPTION
this is the last piece needed to allow the compiler frontend to run shrink_bodyform on functions before full compilation.  this will fold any exposed constants and reduce function bodies to the minimum possible code that doesn't either reference the environment or a named argument of the function.
this is important because we have semantic information much closer to the user before code generation than after, and can make some assumptions before compilation that can't be made after in raw output.
it's also important because src/compiler/evaluate.rs embodies the full intended semantics of chialisp independent of clvm, giving us a more formal starting point for other code generators (particularly proof assistants).