### PR TITLE
Add at-captures to all chialisp dialects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,7 +118,7 @@ dependencies = [
 
 [[package]]
 name = "clvm_tools_rs"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "bls12_381",
  "bytestream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clvm_tools_rs"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -503,3 +503,21 @@ pub fn extract_program_and_env(program: Rc<SExp>) -> Option<(Rc<SExp>, Rc<SExp>)
         _ => None,
     }
 }
+
+pub fn is_at_capture(head: Rc<SExp>, rest: Rc<SExp>) -> Option<(Vec<u8>, Rc<SExp>)> {
+    rest.proper_list().and_then(|l| {
+        if l.len() != 2 {
+            return None;
+        }
+        match (head.borrow(), l[0].borrow()) {
+            (SExp::Atom(_, a), SExp::Atom(_, cap)) => {
+                if a == &vec!['@' as u8] {
+                    return Some((cap.clone(), Rc::new(l[1].clone())));
+                }
+            }
+            _ => {}
+        }
+
+        None
+    })
+}

--- a/src/compiler/evaluate.rs
+++ b/src/compiler/evaluate.rs
@@ -38,7 +38,7 @@ fn select_helper(bindings: &Vec<HelperForm>, name: &Vec<u8>) -> Option<HelperFor
         }
     }
 
-    return None;
+    None
 }
 
 fn update_parallel_bindings(
@@ -168,11 +168,7 @@ fn create_argument_captures(
                 let fused_arguments =
                     Rc::new(make_operator2(l, "c".to_string(), bfa.clone(), bfb.clone()));
                 argument_captures.insert(capture.clone(), fused_arguments);
-                create_argument_captures(
-                    argument_captures,
-                    formed_arguments.clone(),
-                    substructure.clone(),
-                )
+                create_argument_captures(argument_captures, formed_arguments, substructure)
             } else {
                 create_argument_captures(argument_captures, af, f.clone())?;
                 create_argument_captures(argument_captures, ar, r.clone())
@@ -223,7 +219,7 @@ fn build_argument_captures(
     }
 
     let mut argument_captures = HashMap::new();
-    create_argument_captures(&mut argument_captures, &formed_arguments, args.clone())?;
+    create_argument_captures(&mut argument_captures, &formed_arguments, args)?;
     Ok(argument_captures)
 }
 
@@ -325,7 +321,7 @@ fn synthesize_args(
             ))
         }),
         SExp::Cons(l, f, r) => {
-            if let Some((capture, substructure)) = is_at_capture(f.clone(), r.clone()) {
+            if let Some((capture, _substructure)) = is_at_capture(f.clone(), r.clone()) {
                 synthesize_args(Rc::new(SExp::Atom(l.clone(), capture.clone())), env)
             } else {
                 Ok(Rc::new(BodyForm::Call(
@@ -850,13 +846,10 @@ impl Evaluator {
 
     fn get_constant(&self, name: &Vec<u8>) -> Option<Rc<BodyForm>> {
         for h in self.helpers.iter() {
-            match h {
-                HelperForm::Defconstant(_, n, body) => {
-                    if n == name {
-                        return Some(body.clone());
-                    }
+            if let HelperForm::Defconstant(_, n, body) = h {
+                if n == name {
+                    return Some(body.clone());
                 }
-                _ => {}
             }
         }
         None

--- a/src/compiler/evaluate.rs
+++ b/src/compiler/evaluate.rs
@@ -243,7 +243,7 @@ pub fn build_reflex_captures(captures: &mut HashMap<Vec<u8>, Rc<BodyForm>>, args
             if let Some((capture, substructure)) = is_at_capture(a.clone(), b.clone()) {
                 captures.insert(
                     capture.clone(),
-                    Rc::new(BodyForm::Value(SExp::Atom(l.clone(), capture.clone())))
+                    Rc::new(BodyForm::Value(SExp::Atom(l.clone(), capture.clone()))),
                 );
                 build_reflex_captures(captures, substructure);
             } else {
@@ -340,7 +340,7 @@ fn synthesize_args(
                     ],
                 )))
             }
-        },
+        }
         SExp::Nil(l) => Ok(Rc::new(BodyForm::Quoted(SExp::Nil(l.clone())))),
         _ => Err(CompileErr(
             template.loc(),

--- a/src/compiler/rename.rs
+++ b/src/compiler/rename.rs
@@ -92,7 +92,11 @@ fn rename_in_cons(namemap: &HashMap<Vec<u8>, Vec<u8>>, body: Rc<SExp>) -> Rc<SEx
 fn invent_new_names_sexp(body: Rc<SExp>) -> Vec<(Vec<u8>, Vec<u8>)> {
     match body.borrow() {
         SExp::Atom(_, name) => {
-            return vec![(name.to_vec(), gensym(name.to_vec()))];
+            if name != &vec!['@' as u8] {
+                return vec![(name.to_vec(), gensym(name.to_vec()))];
+            } else {
+                return vec![];
+            }
         }
         SExp::Cons(_, head, tail) => {
             let mut head_list = invent_new_names_sexp(head.clone());

--- a/src/tests/classic/run.rs
+++ b/src/tests/classic/run.rs
@@ -116,3 +116,63 @@ fn brun_constant_test() {
         "(q . 3)".to_string()
     );
 }
+
+#[test]
+fn at_capture_destructure_1() {
+    assert_eq!(
+        do_basic_run(&vec!(
+            "run".to_string(),
+            "(mod (A (@ Z (B C)) D) A)".to_string()
+        ))
+        .trim(),
+        "2"
+    );
+}
+
+#[test]
+fn at_capture_destructure_2() {
+    assert_eq!(
+        do_basic_run(&vec!(
+            "run".to_string(),
+            "(mod (A (@ Z (B C)) D) Z)".to_string()
+        ))
+        .trim(),
+        "5"
+    );
+}
+
+#[test]
+fn at_capture_destructure_3() {
+    assert_eq!(
+        do_basic_run(&vec!(
+            "run".to_string(),
+            "(mod (A (@ Z (B C)) D) B)".to_string()
+        ))
+        .trim(),
+        "9"
+    );
+}
+
+#[test]
+fn at_capture_destructure_4() {
+    assert_eq!(
+        do_basic_run(&vec!(
+            "run".to_string(),
+            "(mod (A (@ Z (B C)) D) C)".to_string()
+        ))
+        .trim(),
+        "21"
+    );
+}
+
+#[test]
+fn at_capture_destructure_5() {
+    assert_eq!(
+        do_basic_run(&vec!(
+            "run".to_string(),
+            "(mod (A (@ Z (B C)) D) D)".to_string()
+        ))
+        .trim(),
+        "11"
+    );
+}

--- a/src/tests/compiler/compiler.rs
+++ b/src/tests/compiler/compiler.rs
@@ -681,7 +681,8 @@ fn test_at_destructure_5() {
     .unwrap();
 
     assert_eq!(result.to_string(), "4".to_string());
-=======
+}
+
 fn test_collatz_maybe_opt(opt: bool) {
     let result = run_string_maybe_opt(
         &indoc! {"

--- a/src/tests/compiler/compiler.rs
+++ b/src/tests/compiler/compiler.rs
@@ -535,7 +535,7 @@ fn test_defconstant() {
                 )
               )
         "}.to_string(),
-        &"(hello 0x5f5767744f91c1c326d927a63d9b34fa7035c10e3eb838c44e3afe127c1b7675 2)".to_string(),
+                   &"(hello 0x5f5767744f91c1c326d927a63d9b34fa7035c10e3eb838c44e3afe127c1b7675 2)".to_string(),
         ).unwrap();
 
     assert_eq!(
@@ -596,4 +596,89 @@ fn cant_redefine_defun_with_defun() {
         ));
         assert!(result.is_err());
     }
+}
+
+#[test]
+fn test_at_destructure_1() {
+    let result = run_string(
+        &indoc! {"
+            (mod (A (@ Z (B C)) D)
+              (include *standard-cl-21*) ;; Specify chialisp-21 compilation.
+              A
+              )
+        "}
+        .to_string(),
+        &"(1 (2 3) 4)".to_string(),
+    )
+    .unwrap();
+
+    assert_eq!(result.to_string(), "1".to_string());
+}
+
+#[test]
+fn test_at_destructure_2() {
+    let result = run_string(
+        &indoc! {"
+            (mod (A (@ Z (B C)) D)
+              (include *standard-cl-21*) ;; Specify chialisp-21 compilation.
+              Z
+              )
+        "}
+        .to_string(),
+        &"(1 (2 3) 4)".to_string(),
+    )
+    .unwrap();
+
+    assert_eq!(result.to_string(), "(2 3)".to_string());
+}
+
+#[test]
+fn test_at_destructure_3() {
+    let result = run_string(
+        &indoc! {"
+            (mod (A (@ Z (B C)) D)
+              (include *standard-cl-21*) ;; Specify chialisp-21 compilation.
+              B
+              )
+        "}
+        .to_string(),
+        &"(1 (2 3) 4)".to_string(),
+    )
+    .unwrap();
+
+    assert_eq!(result.to_string(), "2".to_string());
+}
+
+#[test]
+fn test_at_destructure_4() {
+    let result = run_string(
+        &indoc! {"
+            (mod (A (@ Z (B C)) D)
+              (include *standard-cl-21*) ;; Specify chialisp-21 compilation.
+              C
+              )
+        "}
+        .to_string(),
+        &"(1 (2 3) 4)".to_string(),
+    )
+    .unwrap();
+
+    assert_eq!(result.to_string(), "3".to_string());
+}
+
+#[test]
+fn test_at_destructure_5() {
+    let result = run_string(
+        &indoc! {"
+            (mod (A (@ Z (B C)) D)
+              (include *standard-cl-21*) ;; Specify chialisp-21 compilation.
+              D
+              )
+        "}
+        .to_string(),
+        &"(1 (2 3) 4)".to_string(),
+    )
+    .unwrap();
+
+    assert_eq!(result.to_string(), "4".to_string());
 }

--- a/src/tests/compiler/repl.rs
+++ b/src/tests/compiler/repl.rs
@@ -150,9 +150,11 @@ fn test_repl_supports_at_capture() {
         .unwrap()
         .unwrap(),
         "(q 10 2 3)"
-  }
-  
-  fn test_collatz() {
+    );
+}
+
+#[test]
+fn test_collatz() {
     assert_eq!(
         test_repl_outcome(vec![
             "(defun-inline odd (X) (logand X 1))",

--- a/src/tests/compiler/repl.rs
+++ b/src/tests/compiler/repl.rs
@@ -139,3 +139,16 @@ fn test_last_of_pwcoin_2() {
         "(q (51 3735928559 1))"
     );
 }
+
+#[test]
+fn test_repl_supports_at_capture() {
+    assert_eq!(
+        test_repl_outcome(vec![
+            "(defun F (A (@ Z (B C)) D) (c (+ A B C D) Z))",
+            "(F 1 (q 2 3) 4)",
+        ])
+        .unwrap()
+        .unwrap(),
+        "(q 10 2 3)"
+    );
+}


### PR DESCRIPTION
 as it can be added without changing the way code is generated.  

Given (defun F (A (@ Z (B C)) D) (c (+ A B C D) Z)), 
(F 1 (q 2 3) 4) yields (10 2 3). 

the (@ capture substructure) form causes an argument binding to reference the sublist (B C) from the environment but continues on to bind B and C as well, in the same way as haskell's destructuring @

as in the function
foo whole@{part1, part2} = ... 

causes whole to be bound to the whole destructured {part1, part2} structure, but part1 and part2 are also bound.  this should allow structures to be treated as objects and functions as trait functions, supporting an object+vocabulary style common to using objects in functional languages.