### PR TITLE
20220607 fix inline destructuring

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -88,23 +88,6 @@ jobs:
         cd resources/alpine && docker build -t clvm-tools-rs-alpine .
         docker run -v ${GITHUB_WORKSPACE}:/root/clvm_tools_rs -t clvm-tools-rs-alpine sh /root/build-alpine.sh
 
-    - name: Verify recompilation of old sources match
-      if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.python, '3.7')
-      run: |
-        . ./activate
-        # Grab chia-blockchain
-        git clone https://github.com/Chia-Network/chia-blockchain
-        (cd chia-blockchain && python -m pip install -e .)
-
-        # Build and install clvm_tools_rs
-        maturin build --no-sdist -i python --release --strip
-        python support/wheelname.py
-        # Check recompiles
-        cp support/recompile_check.py chia-blockchain
-        (cd chia-blockchain && python recompile_check.py)
-        # Ran successfully, remove
-        rm -rf chia-blockchain
-
     - name: Build Windows with maturin on Python ${{ matrix.python }}
       if: startsWith(matrix.os, 'windows')
       run: |
@@ -152,6 +135,20 @@ jobs:
         python -c 'import clvm; print(clvm.__file__)'
         python -c 'import clvm_rs; print(clvm_rs.__file__)'
         python -c 'import clvm_tools_rs; print(clvm_tools_rs.__file__)'
+
+    - name: Verify recompilation of old sources match
+      if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.python, '3.7')
+      run: |
+        . ./activate
+        # Grab chia-blockchain
+        git clone https://github.com/Chia-Network/chia-blockchain
+
+        # Check recompiles
+        cp support/recompile_check.py chia-blockchain
+        (cd chia-blockchain && python recompile_check.py)
+
+        # Ran successfully, remove
+        rm -rf chia-blockchain
 
     - name: Run tests from clvm
       run: |

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -99,7 +99,7 @@ jobs:
         maturin build --no-sdist -i python --release --strip
         python support/wheelname.py
         # Check recompiles
-        cp support/recompile_check chia-blockchain
+        cp support/recompile_check.py chia-blockchain
         (cd chia-blockchain && python recompile_check.py)
         # Ran successfully, remove
         rm -rf chia-blockchain

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -141,7 +141,7 @@ jobs:
       run: |
         . ./activate
         # Build cmd line tools
-        cargo build --no-default-features --release
+        PYO3_PYTHON=`which python` cargo build --no-default-features --release
 
         # Grab chia-blockchain
         git clone https://github.com/Chia-Network/chia-blockchain

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -141,7 +141,7 @@ jobs:
       run: |
         . ./activate
         # Build cmd line tools
-        cargo build --release
+        cargo build --no-default-features --release
 
         # Grab chia-blockchain
         git clone https://github.com/Chia-Network/chia-blockchain

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -140,11 +140,11 @@ jobs:
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.python, '3.7')
       run: |
         . ./activate
+        # Build cmd line tools
+        cargo build --release
+
         # Grab chia-blockchain
         git clone https://github.com/Chia-Network/chia-blockchain
-
-        echo "installing clvm_rs via pip"
-        pip install clvm_rs
 
         # Check recompiles
         cp support/recompile_check.py chia-blockchain

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -92,7 +92,7 @@ jobs:
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.python, '3.7')
       run: |
         # Grab chia-blockchain
-        git checkout https://github.com/Chia-Network/chia-blockchain
+        git clone https://github.com/Chia-Network/chia-blockchain
         (cd chia-blockchain && python -m pip install -e .)
 
         # Build and install clvm_tools_rs

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -91,6 +91,7 @@ jobs:
     - name: Verify recompilation of old sources match
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.python, '3.7')
       run: |
+        . ./activate
         # Grab chia-blockchain
         git clone https://github.com/Chia-Network/chia-blockchain
         (cd chia-blockchain && python -m pip install -e .)

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -88,6 +88,22 @@ jobs:
         cd resources/alpine && docker build -t clvm-tools-rs-alpine .
         docker run -v ${GITHUB_WORKSPACE}:/root/clvm_tools_rs -t clvm-tools-rs-alpine sh /root/build-alpine.sh
 
+    - name: Verify recompilation of old sources match
+      if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.python, '3.7')
+      run: |
+        # Grab chia-blockchain
+        git checkout https://github.com/Chia-Network/chia-blockchain
+        (cd chia-blockchain && python -m pip install -e .)
+
+        # Build and install clvm_tools_rs
+        maturin build --no-sdist -i python --release --strip
+        python support/wheelname.py
+        # Check recompiles
+        cp support/recompile_check chia-blockchain
+        (cd chia-blockchain && python recompile_check.py)
+        # Ran successfully, remove
+        rm -rf chia-blockchain
+
     - name: Build Windows with maturin on Python ${{ matrix.python }}
       if: startsWith(matrix.os, 'windows')
       run: |

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -143,6 +143,9 @@ jobs:
         # Grab chia-blockchain
         git clone https://github.com/Chia-Network/chia-blockchain
 
+        echo "installing clvm_rs via pip"
+        pip install clvm_rs
+
         # Check recompiles
         cp support/recompile_check.py chia-blockchain
         (cd chia-blockchain && python recompile_check.py)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,7 +118,7 @@ dependencies = [
 
 [[package]]
 name = "clvm_tools_rs"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "bls12_381",
  "bytestream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clvm_tools_rs"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/classic/clvm_tools/stages/stage_2/defaults.rs
+++ b/src/classic/clvm_tools/stages/stage_2/defaults.rs
@@ -77,6 +77,19 @@ fn DEFAULT_MACROS_SRC() -> Vec<&'static str> {
                  (function (unquote C)))
               @)))
         "},
+        indoc! {"
+        (q \"__chia__enlist\"
+            (a (q #a (q #a 2 (c 2 (c 3 (q))))
+                     (c (q #a (i 5
+                                 (q #c (q . 4)
+                                       (c 9 (c (a 2 (c 2 (c 13 (q))))
+                                               (q)))
+                                 )
+                                 (q 1))
+                               1)
+                        1))
+                2))
+        "}
     ];
 }
 

--- a/src/classic/clvm_tools/stages/stage_2/defaults.rs
+++ b/src/classic/clvm_tools/stages/stage_2/defaults.rs
@@ -89,7 +89,7 @@ fn DEFAULT_MACROS_SRC() -> Vec<&'static str> {
                                1)
                         1))
                 2))
-        "}
+        "},
     ];
 }
 

--- a/src/classic/clvm_tools/stages/stage_2/inline.rs
+++ b/src/classic/clvm_tools/stages/stage_2/inline.rs
@@ -1,0 +1,284 @@
+use crate::classic::clvm::__type_compatibility__::{bi_one, bi_zero};
+use crate::classic::clvm::sexp::{enlist, first, flatten, foldM, mapM, non_nil, proper_list, rest};
+use crate::compiler::gensym::gensym;
+use crate::util::Number;
+use clvm_rs::allocator::{Allocator, NodePtr, SExp};
+use clvm_rs::reduction::EvalErr;
+use num_bigint::ToBigInt;
+use std::collections::HashMap;
+
+// If this is an at capture of the form
+// (@ name substructure)
+// then return name and substructure.
+pub fn is_at_capture(
+    allocator: &mut Allocator,
+    tree_first: NodePtr,
+    tree_rest: NodePtr,
+) -> Option<(NodePtr, NodePtr)> {
+    match (
+        allocator.sexp(tree_first),
+        proper_list(allocator, tree_rest, true),
+    ) {
+        (SExp::Atom(a), Some(spec)) => {
+            if allocator.buf(&a) == vec!['@' as u8] && spec.len() == 2 {
+                return Some((spec[0], spec[1]));
+            }
+        }
+        _ => {}
+    }
+
+    None
+}
+
+// (unquote X)
+fn wrap_in_unquote(allocator: &mut Allocator, code: NodePtr) -> Result<NodePtr, EvalErr> {
+    let unquote_atom = allocator.new_atom("unquote".as_bytes())?;
+    enlist(allocator, &vec![unquote_atom, code])
+}
+
+// (__chia__enlist X)
+fn wrap_in_compile_time_list(allocator: &mut Allocator, code: NodePtr) -> Result<NodePtr, EvalErr> {
+    let chia_enlist_atom = allocator.new_atom("__chia__enlist".as_bytes())?;
+    enlist(allocator, &vec![chia_enlist_atom, code])
+}
+
+// Create the sequence of individual tree moves that will translate to
+// (f ...) and (r ...) wrapping to select the given path from a larger structure.
+fn create_path_selection_plan(
+    allocator: &mut Allocator,
+    path: Number,
+    operators: &mut Vec<bool>,
+) -> Result<(), EvalErr> {
+    if path <= bi_one() {
+        Ok(())
+    } else {
+        operators.push(path.clone() % 2_u32.to_bigint().unwrap() == bi_one());
+        create_path_selection_plan(allocator, path / 2_u32.to_bigint().unwrap(), operators)
+    }
+}
+
+// Given a path and code to be wrapped, generate a lookup by path into that code.
+fn wrap_path_selection(
+    allocator: &mut Allocator,
+    path: Number,
+    wrapped: NodePtr,
+) -> Result<NodePtr, EvalErr> {
+    let mut operator_stack = Vec::new();
+    let mut tail = wrapped;
+    create_path_selection_plan(allocator, path, &mut operator_stack)?;
+    for o in operator_stack.iter() {
+        let head_op = if *o { vec![6] } else { vec![5] };
+        let head_atom = allocator.new_atom(&head_op)?;
+        tail = enlist(allocator, &vec![head_atom, tail])?;
+    }
+    Ok(tail)
+}
+
+// Called for each top level argument (left branch) of the argument list of
+// an inline function that does destructuring (has any substructure or non
+// linearity in its argument list).
+//
+// If further captures are encountered, we record them in selections but
+// must continue their substructure as though it belongs to the current capture
+// as the classic macro system handles destructuring on the source text rather
+// than the argument values, so we must eliminate all deep references past the
+// top of the argument list.
+fn formulate_path_selections_for_destructuring_arg(
+    allocator: &mut Allocator,
+    arg_sexp: NodePtr,
+    arg_path: Number,
+    arg_depth: Number,
+    referenced_from: Option<NodePtr>,
+    selections: &mut HashMap<Vec<u8>, NodePtr>,
+) -> Result<NodePtr, EvalErr> {
+    match allocator.sexp(arg_sexp) {
+        SExp::Pair(a, b) => {
+            let next_depth = arg_depth.clone() * 2_u32.to_bigint().unwrap();
+            if let Some((capture, substructure)) = is_at_capture(allocator, a, b) {
+                if let SExp::Atom(cbuf) = allocator.sexp(capture) {
+                    let (new_arg_path, new_arg_depth, tail) =
+                        if let Some(prev_ref) = referenced_from {
+                            (arg_path, arg_depth, prev_ref)
+                        } else {
+                            let capture_code = wrap_in_unquote(allocator, capture)?;
+                            let qtail = wrap_path_selection(
+                                allocator,
+                                arg_path.clone() + arg_depth.clone(),
+                                capture_code,
+                            )?;
+                            (bi_zero(), bi_one(), qtail)
+                        };
+
+                    selections.insert(allocator.buf(&cbuf).to_vec(), tail);
+
+                    formulate_path_selections_for_destructuring_arg(
+                        allocator,
+                        substructure,
+                        new_arg_path,
+                        new_arg_depth,
+                        Some(tail),
+                        selections,
+                    );
+                    return Ok(arg_sexp);
+                }
+            }
+
+            if let Some(_) = referenced_from {
+                let f = formulate_path_selections_for_destructuring_arg(
+                    allocator,
+                    a,
+                    arg_path.clone(),
+                    next_depth.clone(),
+                    referenced_from.clone(),
+                    selections,
+                )?;
+                let r = formulate_path_selections_for_destructuring_arg(
+                    allocator,
+                    b,
+                    arg_depth.clone() + arg_path,
+                    next_depth,
+                    referenced_from,
+                    selections,
+                )?;
+                allocator.new_pair(f, r)
+            } else {
+                let ref_name = gensym("destructuring_capture".as_bytes().to_vec());
+                let at_atom = allocator.new_atom("@".as_bytes())?;
+                let name_atom = allocator.new_atom(&ref_name)?;
+                let new_arg_list = enlist(allocator, &vec![at_atom, name_atom, arg_sexp])?;
+                formulate_path_selections_for_destructuring_arg(
+                    allocator,
+                    new_arg_list,
+                    bi_zero(),
+                    bi_one(),
+                    None,
+                    selections,
+                )
+            }
+        }
+        SExp::Atom(b) => {
+            let buf = allocator.buf(&b).to_vec();
+            if buf.len() > 0 {
+                if let Some(capture) = referenced_from {
+                    let tail = wrap_path_selection(
+                        allocator,
+                        arg_path.clone() + arg_depth.clone(),
+                        capture,
+                    )?;
+                    selections.insert(buf, tail);
+                    return Ok(arg_sexp);
+                }
+            }
+            Ok(arg_sexp)
+        }
+    }
+}
+
+// These generate a new argument list that will use at-captures to identify
+// roots to pick data out of in the eventual macro code that's emitted.  This
+// is needed because macros and functions work differently.  While functions
+// conceptually receive an environment and choose values out of it, macros
+// bind parameters to the source code the user used to invoke them; therefore
+// destructuring can be problematic
+//
+// Consider this example:
+//
+//   (defun-inline F ((A B C)) (+ A B C))
+//
+// Without supporting destructuring consciously, this will be turned by
+// classic chialisp into a macro like this:
+//
+//   (defmacro F ((A B C)) (+ A B C))
+//
+// Which destructures the source text of the program:
+//
+//   (F (4 1 (list 2 3))) would be expected to output 6
+//
+// But instead, the destructuring gives:
+//
+//   (+ 4 1 (list 2 3))
+//
+// We insert a capture for any top level argument that is non-proper:
+//
+//   (defun-inline F ((@ destructuring_capture_$_1 (A B C))) (+ A B C))
+//
+// And "selections" contains the code that should be used in place of simply
+// unquoting a named argument:
+//
+//   { "A": (f (unquote destructuring_capture_$_1)),
+//     "B": (f (r (unquote destructuring_capture_$_1))
+//     ...
+//
+// There is a unique case to deal with:
+//
+//   (defun-inline offset-of-pt (@ pt (X Y)) (+ X (* 8 Y)))
+//
+// Because pt represents the entire argument list, it will be in this form when
+// unquoted:
+//
+//   (offset-of-pt 3 2) -> pt = (3 2)
+//
+// When substituted:
+//
+//   (offset-of-pt 3 2) -> (+ (f (3 2)) (* 8 (f (r (3 2)))))
+//
+// Simply quoting won't solve it, because the code may do something
+//
+//   (offset-of-pt (+ 1 Q) (- W 2)) -> (+ (f ((+ 1 Q) (- W 2))) ...)
+//
+// So we need a macro like "list" that starts not from the entire input
+// environment but that destructures just its first argument as a list,
+// so i adapted list into __chia__enlist.
+// When so wrapped, the user may then destructure the capture argument.
+pub fn formulate_path_selections_for_destructuring(
+    allocator: &mut Allocator,
+    args_sexp: NodePtr,
+    selections: &mut HashMap<Vec<u8>, NodePtr>,
+) -> Result<NodePtr, EvalErr> {
+    if let SExp::Pair(a, b) = allocator.sexp(args_sexp) {
+        if let Some((capture, substructure)) = is_at_capture(allocator, a, b) {
+            if let SExp::Atom(cbuf) = allocator.sexp(capture) {
+                let quoted_arg_list = wrap_in_unquote(allocator, capture)?;
+                let tail = wrap_in_compile_time_list(allocator, quoted_arg_list)?;
+                let buf = allocator.buf(&cbuf);
+                selections.insert(buf.to_vec(), tail);
+                let newsub = formulate_path_selections_for_destructuring_arg(
+                    allocator,
+                    substructure,
+                    bi_zero(),
+                    bi_one(),
+                    Some(tail),
+                    selections,
+                )?;
+                return enlist(allocator, &vec![a, capture, newsub]);
+            }
+        }
+        let f = formulate_path_selections_for_destructuring_arg(
+            allocator,
+            a,
+            bi_zero(),
+            bi_one(),
+            None,
+            selections,
+        )?;
+        let r = formulate_path_selections_for_destructuring(allocator, b, selections)?;
+        allocator.new_pair(f, r)
+    } else {
+        Ok(args_sexp)
+    }
+}
+
+// If true, these arguments represent a destructuring of some kind.
+// In the case of inlines in classic chialisp, we must adjust how arguments
+// are passed down to the macro body that gets created for the inline function.
+pub fn is_inline_destructure(allocator: &mut Allocator, args_sexp: NodePtr) -> bool {
+    if let SExp::Pair(a, b) = allocator.sexp(args_sexp) {
+        if let SExp::Pair(_, _) = allocator.sexp(a) {
+            return true;
+        }
+
+        return is_inline_destructure(allocator, b);
+    }
+
+    false
+}

--- a/src/classic/clvm_tools/stages/stage_2/mod.rs
+++ b/src/classic/clvm_tools/stages/stage_2/mod.rs
@@ -1,6 +1,7 @@
 pub mod compile;
 pub mod defaults;
 pub mod helpers;
+pub mod inline;
 pub mod module;
 pub mod operators;
 pub mod optimize;

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -6,7 +6,7 @@ pub mod comptypes;
 pub mod debug;
 pub mod evaluate;
 pub mod frontend;
-mod gensym;
+pub mod gensym;
 mod inline;
 mod optimize;
 pub mod preprocessor;

--- a/src/tests/classic/run.rs
+++ b/src/tests/classic/run.rs
@@ -184,7 +184,7 @@ fn at_capture_inline_1() {
             "run".to_string(),
             "(mod () (defun-inline F (@ pt (X Y)) X) (F 97 98))".to_string()
         ))
-            .trim(),
+        .trim(),
         "(q . 97)"
     );
 }
@@ -196,7 +196,7 @@ fn at_capture_inline_2() {
             "run".to_string(),
             "(mod () (defun-inline F (@ pt (X Y)) Y) (F 97 98))".to_string()
         ))
-            .trim(),
+        .trim(),
         "(q . 98)"
     );
 }
@@ -208,7 +208,7 @@ fn at_capture_inline_3() {
             "run".to_string(),
             "(mod () (defun-inline F (@ pt (X Y)) pt) (F (+ 117 1) (+ 98 1)))".to_string()
         ))
-            .trim(),
+        .trim(),
         "(q 118 99)"
     );
 }
@@ -232,7 +232,7 @@ fn inline_destructure_1() {
             "run".to_string(),
             "(mod () (defun-inline F ((A . B)) (+ A B)) (F (c 3 7)))".to_string()
         ))
-            .trim(),
+        .trim(),
         "(q . 10)"
     );
 }

--- a/src/tests/classic/run.rs
+++ b/src/tests/classic/run.rs
@@ -176,3 +176,51 @@ fn at_capture_destructure_5() {
         "11"
     );
 }
+
+#[test]
+fn at_capture_inline_1() {
+    assert_eq!(
+        do_basic_run(&vec!(
+            "run".to_string(),
+            "(mod () (defun-inline F (@ pt (X Y)) X) (F 97 98))".to_string()
+        ))
+            .trim(),
+        "(q . 97)"
+    );
+}
+
+#[test]
+fn at_capture_inline_2() {
+    assert_eq!(
+        do_basic_run(&vec!(
+            "run".to_string(),
+            "(mod () (defun-inline F (@ pt (X Y)) Y) (F 97 98))".to_string()
+        ))
+            .trim(),
+        "(q . 98)"
+    );
+}
+
+#[test]
+fn at_capture_inline_3() {
+    assert_eq!(
+        do_basic_run(&vec!(
+            "run".to_string(),
+            "(mod () (defun-inline F (@ pt (X Y)) pt) (F (+ 117 1) (+ 98 1)))".to_string()
+        ))
+            .trim(),
+        "(q 118 99)"
+    );
+}
+
+#[test]
+fn at_capture_inline_4() {
+    assert_eq!(
+        do_basic_run(&vec!(
+            "run".to_string(),
+            "(mod () (defun-inline F (A (@ pt (X Y))) (list (list A X Y) pt)) (F 115 (list 99 77)))".to_string()
+        ))
+            .trim(),
+        "(q (115 99 77) (99 77))"
+    );
+}

--- a/src/tests/classic/run.rs
+++ b/src/tests/classic/run.rs
@@ -236,3 +236,15 @@ fn inline_destructure_1() {
         "(q . 10)"
     );
 }
+
+#[test]
+fn test_forms_of_destructuring_allowed_by_classic_1() {
+    assert_eq!(
+        do_basic_run(&vec![
+            "run".to_string(),
+            "(mod (A) (defun-inline foo (X Y . Z) (i X Y . Z)) (foo A 2 3))".to_string()
+        ])
+        .trim(),
+        "(i 2 (q . 2) (q . 3))"
+    );
+}

--- a/src/tests/classic/run.rs
+++ b/src/tests/classic/run.rs
@@ -224,3 +224,15 @@ fn at_capture_inline_4() {
         "(q (115 99 77) (99 77))"
     );
 }
+
+#[test]
+fn inline_destructure_1() {
+    assert_eq!(
+        do_basic_run(&vec!(
+            "run".to_string(),
+            "(mod () (defun-inline F ((A . B)) (+ A B)) (F (c 3 7)))".to_string()
+        ))
+            .trim(),
+        "(q . 10)"
+    );
+}

--- a/support/recompile_check.py
+++ b/support/recompile_check.py
@@ -1,0 +1,60 @@
+import os
+import traceback
+from chia.wallet.puzzles.load_clvm import load_clvm
+
+recompile_list = [
+    'block_program_zero.clvm',
+    'calculate_synthetic_public_key.clvm',
+    'cat.clvm',
+    'chialisp_deserialisation.clvm',
+    'decompress_coin_spend_entry.clvm',
+    'decompress_coin_spend_entry_with_prefix.clvm',
+    'decompress_puzzle.clvm',
+    'delegated_tail.clvm',
+    'did_innerpuz.clvm',
+    'everything_with_signature.clvm',
+    'generator_for_single_coin.clvm',
+    'genesis_by_coin_id.clvm',
+    'genesis_by_puzzle_hash.clvm',
+    'lock.inner.puzzle.clvm',
+    'nft_metadata_updater_default.clvm',
+    'nft_metadata_updater_updateable.clvm',
+    'nft_ownership_layer.clvm',
+    'nft_ownership_transfer_program_one_way_claim_with_royalties.clvm',
+    'nft_ownership_transfer_program_one_way_claim_with_royalties_new.clvm',
+    'nft_state_layer.clvm',
+    'p2_conditions.clvm',
+    'p2_delegated_conditions.clvm',
+    'p2_delegated_puzzle.clvm',
+    'p2_delegated_puzzle_or_hidden_puzzle.clvm',
+    'p2_m_of_n_delegate_direct.clvm',
+    'p2_puzzle_hash.clvm',
+    'p2_singleton.clvm',
+    'p2_singleton_or_delayed_puzhash.clvm',
+    'pool_member_innerpuz.clvm',
+    'pool_waitingroom_innerpuz.clvm',
+    'rl_aggregation.clvm',
+    'rl.clvm',
+    'rom_bootstrap_generator.clvm',
+    'settlement_payments.clvm',
+    'sha256tree_module.clvm',
+    'singleton_launcher.clvm',
+    'singleton_top_layer.clvm',
+    'singleton_top_layer_v1_1.clvm',
+    'test_generator_deserialize.clvm',
+    'test_multiple_generator_input_arguments.clvm'
+]
+
+for fname in recompile_list:
+    hexfile = f'./chia/wallet/puzzles/{fname}.hex'
+    hexdata = open(hexfile).read().strip()
+    os.unlink(hexfile)
+    try:
+        recompile = str(load_clvm(fname)).strip()
+    except:
+        print(f'compiling {fname}')
+        traceback.print_exc()
+
+    if hexdata != recompile:
+        print(f'*** COMPILE RESULTED IN DIFFERENT OUTPUT FOR FILE {fname}')
+        assert hexdata == recompile

--- a/support/recompile_check.py
+++ b/support/recompile_check.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import traceback
 from chia.wallet.puzzles.load_clvm import load_clvm
 
@@ -50,7 +51,8 @@ for fname in recompile_list:
     hexdata = open(hexfile).read().strip()
     os.unlink(hexfile)
     try:
-        recompile = str(load_clvm(fname)).strip()
+        compiled = subprocess.check_output(['../target/release/run', '-i', 'chia/wallet/puzzles/', f'chia/wallet/puzzles/{fname}']).strip()
+        recompile = subprocess.check_output(['../target/release/opc', compiled]).decode('utf8').strip()
     except:
         print(f'compiling {fname}')
         traceback.print_exc()

--- a/support/recompile_check.py
+++ b/support/recompile_check.py
@@ -1,7 +1,6 @@
 import os
 import subprocess
 import traceback
-from chia.wallet.puzzles.load_clvm import load_clvm
 
 recompile_list = [
     'block_program_zero.clvm',


### PR DESCRIPTION
This should allow all normal types of destructuring to work in inline functions in classic chialisp.  Some synthesis is required to handle various conditions:
 - root level at capture needs the argument list to be reconstituted via a list-like macro otherwise the lack of a first operator prevents us from continuing evaulation.
 - we rely on at-style destructuring to give anchor names to nameless argument forms
 - non-root at capture injects a name and resets path and distance to argument if appropriate.