### PR TITLE
20220610 parameter use checker

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -144,14 +144,12 @@ jobs:
         PYO3_PYTHON=`which python` cargo build --no-default-features --release
 
         # Grab chia-blockchain
+        rm -rf chia-blockchain
         git clone https://github.com/Chia-Network/chia-blockchain
 
         # Check recompiles
         cp support/recompile_check.py chia-blockchain
         (cd chia-blockchain && python recompile_check.py)
-
-        # Ran successfully, remove
-        rm -rf chia-blockchain
 
     - name: Run tests from clvm
       run: |

--- a/chia-blockchain/chia/wallet/puzzles/curry-and-treehash.clinc
+++ b/chia-blockchain/chia/wallet/puzzles/curry-and-treehash.clinc
@@ -1,0 +1,72 @@
+(
+  ;; The code below is used to calculate of the tree hash of a curried function
+  ;; without actually doing the curry, and using other optimization tricks
+  ;; like unrolling `sha256tree`.
+
+  (defconstant ONE 1)
+  (defconstant TWO 2)
+  (defconstant A_KW #a)
+  (defconstant Q_KW #q)
+  (defconstant C_KW #c)
+
+  ;; Given the tree hash `environment-hash` of an environment tree E
+  ;; and the tree hash `parameter-hash` of a constant parameter P
+  ;; return the tree hash of the tree corresponding to
+  ;; `(c (q . P) E)`
+  ;; This is the new environment tree with the addition parameter P curried in.
+  ;;
+  ;; Note that `(c (q . P) E)` = `(c . ((q . P) . (E . 0)))`
+
+  (defun-inline update-hash-for-parameter-hash (parameter-hash environment-hash)
+     (sha256 TWO (sha256 ONE C_KW)
+                 (sha256 TWO (sha256 TWO (sha256 ONE Q_KW) parameter-hash)
+                             (sha256 TWO environment-hash (sha256 ONE 0))))
+  )
+
+  ;; This function recursively calls `update-hash-for-parameter-hash`, updating `environment-hash`
+  ;; along the way.
+
+  (defun build-curry-list (reversed-curry-parameter-hashes environment-hash)
+     (if reversed-curry-parameter-hashes
+         (build-curry-list (r reversed-curry-parameter-hashes)
+                           (update-hash-for-parameter-hash (f reversed-curry-parameter-hashes) environment-hash))
+         environment-hash
+     )
+  )
+
+  ;; Given the tree hash `environment-hash` of an environment tree E
+  ;; and the tree hash `function-hash` of a function tree F
+  ;; return the tree hash of the tree corresponding to
+  ;; `(a (q . F) E)`
+  ;; This is the hash of a new function that adopts the new environment E.
+  ;; This is used to build of the tree hash of a curried function.
+  ;;
+  ;; Note that `(a (q . F) E)` = `(a . ((q . F)  . (E . 0)))`
+
+  (defun-inline tree-hash-of-apply (function-hash environment-hash)
+     (sha256 TWO (sha256 ONE A_KW)
+                 (sha256 TWO (sha256 TWO (sha256 ONE Q_KW) function-hash)
+                             (sha256 TWO environment-hash (sha256 ONE 0))))
+  )
+
+  ;; function-hash:
+  ;;   the hash of a puzzle function, ie. a `mod`
+  ;;
+  ;; reversed-curry-parameter-hashes:
+  ;;   a list of pre-hashed trees representing parameters to be curried into the puzzle.
+  ;;   Note that this must be applied in REVERSED order. This may seem strange, but it greatly simplifies
+  ;;   the underlying code, since we calculate the tree hash from the bottom nodes up, and the last
+  ;;   parameters curried must have their hashes calculated first.
+  ;;
+  ;; we return the hash of the curried expression
+  ;;   (a (q . function-hash) (c (cp1 (c cp2 (c ... 1)...))))
+  ;;
+  ;; Note that from a user's perspective the hashes passed in here aren't simply
+  ;; the hashes of the desired parameters, but their treehash representation since
+  ;; that's the form we're assuming they take in the acutal curried program.
+
+  (defun puzzle-hash-of-curried-function (function-hash . reversed-curry-parameter-hashes)
+     (tree-hash-of-apply function-hash
+                         (build-curry-list reversed-curry-parameter-hashes (sha256 ONE ONE)))
+  )
+)

--- a/resources/tests/assert.clvm
+++ b/resources/tests/assert.clvm
@@ -1,0 +1,21 @@
+(mod (A prev-coin-bundle B)
+     (defmacro assert items
+       (if (r items)
+           (list if (f items) (c assert (r items)) (q . (x)))
+         (f items)
+         )
+       )
+
+     (defun is-valid-bundle ((X . Y) Z)
+       (sha256 X Y Z)
+       )
+
+     (defun main (A prev-coin-bundle B)
+       (assert
+        (is-valid-bundle (+ 1 A) prev-coin-bundle B)
+        (is-valid-bundle (+ 2 A) prev-coin-bundle B)
+        )
+       )
+
+     (main A prev-coin-bundle B)
+     )

--- a/resources/tests/cat_truths.clib
+++ b/resources/tests/cat_truths.clib
@@ -1,0 +1,31 @@
+(
+  (defun-inline cat_truth_data_to_truth_struct (innerpuzhash cat_struct my_id this_coin_info)
+    (c
+      (c
+        innerpuzhash
+        cat_struct
+      )
+      (c
+        my_id
+        this_coin_info
+      )
+    )
+  )
+
+  ; CAT Truths is: ((Inner puzzle hash . (MOD hash . (MOD hash hash . TAIL hash))) . (my_id . (my_parent_info my_puzhash my_amount)))
+
+  (defun-inline my_inner_puzzle_hash_cat_truth (Truths) (f (f Truths)))
+  (defun-inline cat_struct_truth (Truths) (r (f Truths)))
+  (defun-inline my_id_cat_truth (Truths) (f (r Truths)))
+  (defun-inline my_coin_info_truth (Truths) (r (r Truths)))
+  (defun-inline my_amount_cat_truth (Truths) (f (r (r (my_coin_info_truth Truths)))))
+  (defun-inline my_full_puzzle_hash_cat_truth (Truths) (f (r (my_coin_info_truth Truths))))
+  (defun-inline my_parent_cat_truth (Truths) (f (my_coin_info_truth Truths)))
+
+
+  ; CAT mod_struct is: (MOD_HASH MOD_HASH_hash TAIL_PROGRAM TAIL_PROGRAM_hash)
+
+  (defun-inline cat_mod_hash_truth (Truths) (f (cat_struct_truth Truths)))
+  (defun-inline cat_mod_hash_hash_truth (Truths) (f (r (cat_struct_truth Truths))))
+  (defun-inline cat_tail_program_hash_truth (Truths) (f (r (r (cat_struct_truth Truths)))))
+)

--- a/resources/tests/condition_codes.clvm
+++ b/resources/tests/condition_codes.clvm
@@ -1,0 +1,38 @@
+; See chia/types/condition_opcodes.py
+
+(
+    (defconstant AGG_SIG_UNSAFE 49)
+    (defconstant AGG_SIG_ME 50)
+
+    ; the conditions below reserve coin amounts and have to be accounted for in output totals
+
+    (defconstant CREATE_COIN 51)
+    (defconstant RESERVE_FEE 52)
+
+    ; the conditions below deal with announcements, for inter-coin communication
+
+    ; coin announcements
+    (defconstant CREATE_COIN_ANNOUNCEMENT 60)
+    (defconstant ASSERT_COIN_ANNOUNCEMENT 61)
+
+    ; puzzle announcements
+    (defconstant CREATE_PUZZLE_ANNOUNCEMENT 62)
+    (defconstant ASSERT_PUZZLE_ANNOUNCEMENT 63)
+
+    ; the conditions below let coins inquire about themselves
+
+    (defconstant ASSERT_MY_COIN_ID 70)
+    (defconstant ASSERT_MY_PARENT_ID 71)
+    (defconstant ASSERT_MY_PUZZLEHASH 72)
+    (defconstant ASSERT_MY_AMOUNT 73)
+
+    ; the conditions below ensure that we're "far enough" in the future
+
+    ; wall-clock time
+    (defconstant ASSERT_SECONDS_RELATIVE 80)
+    (defconstant ASSERT_SECONDS_ABSOLUTE 81)
+
+    ; block index
+    (defconstant ASSERT_HEIGHT_RELATIVE 82)
+    (defconstant ASSERT_HEIGHT_ABSOLUTE 83)
+)

--- a/resources/tests/curry-and-treehash.clinc
+++ b/resources/tests/curry-and-treehash.clinc
@@ -1,0 +1,72 @@
+(
+  ;; The code below is used to calculate of the tree hash of a curried function
+  ;; without actually doing the curry, and using other optimization tricks
+  ;; like unrolling `sha256tree`.
+
+  (defconstant ONE 1)
+  (defconstant TWO 2)
+  (defconstant A_KW #a)
+  (defconstant Q_KW #q)
+  (defconstant C_KW #c)
+
+  ;; Given the tree hash `environment-hash` of an environment tree E
+  ;; and the tree hash `parameter-hash` of a constant parameter P
+  ;; return the tree hash of the tree corresponding to
+  ;; `(c (q . P) E)`
+  ;; This is the new environment tree with the addition parameter P curried in.
+  ;;
+  ;; Note that `(c (q . P) E)` = `(c . ((q . P) . (E . 0)))`
+
+  (defun-inline update-hash-for-parameter-hash (parameter-hash environment-hash)
+     (sha256 TWO (sha256 ONE C_KW)
+                 (sha256 TWO (sha256 TWO (sha256 ONE Q_KW) parameter-hash)
+                             (sha256 TWO environment-hash (sha256 ONE 0))))
+  )
+
+  ;; This function recursively calls `update-hash-for-parameter-hash`, updating `environment-hash`
+  ;; along the way.
+
+  (defun build-curry-list (reversed-curry-parameter-hashes environment-hash)
+     (if reversed-curry-parameter-hashes
+         (build-curry-list (r reversed-curry-parameter-hashes)
+                           (update-hash-for-parameter-hash (f reversed-curry-parameter-hashes) environment-hash))
+         environment-hash
+     )
+  )
+
+  ;; Given the tree hash `environment-hash` of an environment tree E
+  ;; and the tree hash `function-hash` of a function tree F
+  ;; return the tree hash of the tree corresponding to
+  ;; `(a (q . F) E)`
+  ;; This is the hash of a new function that adopts the new environment E.
+  ;; This is used to build of the tree hash of a curried function.
+  ;;
+  ;; Note that `(a (q . F) E)` = `(a . ((q . F)  . (E . 0)))`
+
+  (defun-inline tree-hash-of-apply (function-hash environment-hash)
+     (sha256 TWO (sha256 ONE A_KW)
+                 (sha256 TWO (sha256 TWO (sha256 ONE Q_KW) function-hash)
+                             (sha256 TWO environment-hash (sha256 ONE 0))))
+  )
+
+  ;; function-hash:
+  ;;   the hash of a puzzle function, ie. a `mod`
+  ;;
+  ;; reversed-curry-parameter-hashes:
+  ;;   a list of pre-hashed trees representing parameters to be curried into the puzzle.
+  ;;   Note that this must be applied in REVERSED order. This may seem strange, but it greatly simplifies
+  ;;   the underlying code, since we calculate the tree hash from the bottom nodes up, and the last
+  ;;   parameters curried must have their hashes calculated first.
+  ;;
+  ;; we return the hash of the curried expression
+  ;;   (a (q . function-hash) (c (cp1 (c cp2 (c ... 1)...))))
+  ;;
+  ;; Note that from a user's perspective the hashes passed in here aren't simply
+  ;; the hashes of the desired parameters, but their treehash representation since
+  ;; that's the form we're assuming they take in the acutal curried program.
+
+  (defun puzzle-hash-of-curried-function (function-hash . reversed-curry-parameter-hashes)
+     (tree-hash-of-apply function-hash
+                         (build-curry-list reversed-curry-parameter-hashes (sha256 ONE ONE)))
+  )
+)

--- a/resources/tests/json.clib
+++ b/resources/tests/json.clib
@@ -1,0 +1,25 @@
+(
+
+  (defun search_list_then_resume (key json_object result)
+    (if result
+      result
+      (search_for_value_given_key key (r json_object))
+    )
+  )
+
+  (defun search_for_value_given_key (key json_object)
+    (if json_object
+      (if (l (f from_json_dict)) ; if we are hitting an unlabelled item (atom), just move on
+        (if (= (f (f json_object)) key)  ; if we have found our key
+          (r (f json_object))  ; return the value
+          (if (l (r (f json_object)))  ; otherwise check if we have hit another dictionary
+            (search_list_then_resume key json_object (search_for_value_given_key key (r (f json_object)))) ; check new dictionary
+            (search_for_value_given_key key (r json_object))
+          )
+        )
+        (search_for_value_given_key key (r json_object))
+      )
+      ()
+    )
+  )
+)

--- a/resources/tests/sha256tree.clib
+++ b/resources/tests/sha256tree.clib
@@ -1,0 +1,11 @@
+(
+    ;; hash a tree
+    ;; This is used to calculate a puzzle hash given a puzzle program.
+    (defun sha256tree
+        (TREE)
+        (if (l TREE)
+            (sha256 2 (sha256tree (f TREE)) (sha256tree (r TREE)))
+            (sha256 1 TREE)
+        )
+    )
+)

--- a/resources/tests/singleton_top_layer.clvm
+++ b/resources/tests/singleton_top_layer.clvm
@@ -1,0 +1,177 @@
+(mod (SINGLETON_STRUCT INNER_PUZZLE lineage_proof my_amount inner_solution)
+
+;; SINGLETON_STRUCT = (MOD_HASH . (LAUNCHER_ID . LAUNCHER_PUZZLE_HASH))
+
+; SINGLETON_STRUCT, INNER_PUZZLE are curried in by the wallet
+
+; EXAMPLE SOLUTION '(0xfadeddab 0xdeadbeef 1 (0xdeadbeef 200) 50 ((51 0xfadeddab 100) (60 "trash") (51 deadbeef 0)))'
+
+
+; This puzzle is a wrapper around an inner smart puzzle which guarantees uniqueness.
+; It takes its singleton identity from a coin with a launcher puzzle which guarantees that it is unique.
+
+  (include condition_codes.clvm)
+  (include curry-and-treehash.clinc)
+  (include singleton_truths.clib)
+
+  ; takes a lisp tree and returns the hash of it
+  (defun sha256tree1 (TREE)
+      (if (l TREE)
+          (sha256 2 (sha256tree1 (f TREE)) (sha256tree1 (r TREE)))
+          (sha256 1 TREE)
+      )
+  )
+
+  ; "assert" is a macro that wraps repeated instances of "if"
+  ; usage: (assert A0 A1 ... An R)
+  ; all of A0, A1, ... An must evaluate to non-null, or an exception is raised
+  ; return the value of R (if we get that far)
+
+  (defmacro assert items
+    (if (r items)
+        (list if (f items) (c assert (r items)) (q . (x)))
+        (f items)
+    )
+  )
+
+  (defun-inline mod_hash_for_singleton_struct (SINGLETON_STRUCT) (f SINGLETON_STRUCT))
+  (defun-inline launcher_id_for_singleton_struct (SINGLETON_STRUCT) (f (r SINGLETON_STRUCT)))
+  (defun-inline launcher_puzzle_hash_for_singleton_struct (SINGLETON_STRUCT) (r (r SINGLETON_STRUCT)))
+
+  ;; return the full puzzlehash for a singleton with the innerpuzzle curried in
+  ; puzzle-hash-of-curried-function is imported from curry-and-treehash.clinc
+  (defun-inline calculate_full_puzzle_hash (SINGLETON_STRUCT inner_puzzle_hash)
+     (puzzle-hash-of-curried-function (mod_hash_for_singleton_struct SINGLETON_STRUCT)
+                                      inner_puzzle_hash
+                                      (sha256tree1 SINGLETON_STRUCT)
+     )
+  )
+
+  ; assembles information from the solution to create our own full ID including asserting our parent is a singleton
+  (defun create_my_ID (SINGLETON_STRUCT full_puzzle_hash parent_parent parent_inner_puzzle_hash parent_amount my_amount)
+    (sha256 (sha256 parent_parent (calculate_full_puzzle_hash SINGLETON_STRUCT parent_inner_puzzle_hash) parent_amount)
+            full_puzzle_hash
+            my_amount)
+  )
+
+  ;; take a boolean and a non-empty list of conditions
+  ;; strip off the first condition if a boolean is set
+  ;; this is used to remove `(CREATE_COIN xxx -113)`
+  ;; pretty sneaky, eh?
+  (defun strip_first_condition_if (boolean condition_list)
+    (if boolean
+      (r condition_list)
+      condition_list
+    )
+  )
+
+  (defun-inline morph_condition (condition SINGLETON_STRUCT)
+    (list (f condition) (calculate_full_puzzle_hash SINGLETON_STRUCT (f (r condition))) (f (r (r condition))))
+  )
+
+  ;; return the value of the coin created if this is a `CREATE_COIN` condition, or 0 otherwise
+  (defun-inline created_coin_value_or_0 (condition)
+    (if (= (f condition) CREATE_COIN)
+        (f (r (r condition)))
+        0
+    )
+  )
+
+  ;; Returns a (bool . bool)
+  (defun odd_cons_m113 (output_amount)
+    (c
+      (= (logand output_amount 1) 1) ;; is it odd?
+      (= output_amount -113) ;; is it the escape value?
+    )
+  )
+
+  ; Assert exactly one output with odd value exists - ignore it if value is -113
+
+  ;; this function iterates over the output conditions from the inner puzzle & solution
+  ;; and both checks that exactly one unique singleton child is created (with odd valued output),
+  ;; and wraps the inner puzzle with this same singleton wrapper puzzle
+  ;;
+  ;; The special case where the output value is -113 means a child singleton is intentionally
+  ;; *NOT* being created, thus forever ending this singleton's existence
+
+  (defun check_and_morph_conditions_for_singleton (SINGLETON_STRUCT conditions has_odd_output_been_found)
+    (if conditions
+        (morph_next_condition SINGLETON_STRUCT conditions has_odd_output_been_found (odd_cons_m113 (created_coin_value_or_0 (f conditions))))
+          (if has_odd_output_been_found
+              0
+              (x)  ;; no odd output found
+          )
+        )
+   )
+
+   ;; a continuation of `check_and_morph_conditions_for_singleton` with booleans `is_output_odd` and `is_output_m113`
+   ;; precalculated
+   (defun morph_next_condition (SINGLETON_STRUCT conditions has_odd_output_been_found (is_output_odd . is_output_m113))
+       (assert
+          (not (all is_output_odd has_odd_output_been_found))
+          (strip_first_condition_if
+             is_output_m113
+             (c (if is_output_odd
+                    (morph_condition (f conditions) SINGLETON_STRUCT)
+                    (f conditions)
+                )
+                (check_and_morph_conditions_for_singleton SINGLETON_STRUCT (r conditions) (any is_output_odd has_odd_output_been_found))
+             )
+          )
+      )
+   )
+
+  ; this final stager asserts our ID
+  ; it also runs the innerpuz with the innersolution with the "truths" added
+  ; it then passes that output conditions from the innerpuz to the morph conditions function
+  (defun stager_three (SINGLETON_STRUCT lineage_proof my_id full_puzhash innerpuzhash my_amount INNER_PUZZLE inner_solution)
+    (c (list ASSERT_MY_COIN_ID my_id) (check_and_morph_conditions_for_singleton SINGLETON_STRUCT (a INNER_PUZZLE (c (truth_data_to_truth_struct my_id full_puzhash innerpuzhash my_amount lineage_proof SINGLETON_STRUCT) inner_solution)) 0))
+  )
+
+  ; this checks whether we are an eve spend or not and calculates our full coin ID appropriately and passes it on to the final stager
+  ; if we are the eve spend it also adds the additional checks that our parent's puzzle is the standard launcher format and that out parent ID is the same as our singleton ID
+
+  (defun stager_two (SINGLETON_STRUCT lineage_proof full_puzhash innerpuzhash my_amount INNER_PUZZLE inner_solution)
+    (stager_three
+      SINGLETON_STRUCT
+      lineage_proof
+      (if (is_not_eve_proof lineage_proof)
+          (create_my_ID
+            SINGLETON_STRUCT
+            full_puzhash
+            (parent_info_for_lineage_proof lineage_proof)
+            (puzzle_hash_for_lineage_proof lineage_proof)
+            (amount_for_lineage_proof lineage_proof)
+            my_amount
+          )
+          (if (=
+                (launcher_id_for_singleton_struct SINGLETON_STRUCT)
+                (sha256 (parent_info_for_eve_proof lineage_proof) (launcher_puzzle_hash_for_singleton_struct SINGLETON_STRUCT) (amount_for_eve_proof lineage_proof))
+              )
+              (sha256 (launcher_id_for_singleton_struct SINGLETON_STRUCT) full_puzhash my_amount)
+              (x)
+          )
+      )
+      full_puzhash
+      innerpuzhash
+      my_amount
+      INNER_PUZZLE
+      inner_solution
+    )
+  )
+
+  ; this calculates our current full puzzle hash and passes it to stager two
+  (defun stager_one (SINGLETON_STRUCT lineage_proof my_innerpuzhash my_amount INNER_PUZZLE inner_solution)
+    (stager_two SINGLETON_STRUCT lineage_proof (calculate_full_puzzle_hash SINGLETON_STRUCT my_innerpuzhash) my_innerpuzhash my_amount INNER_PUZZLE inner_solution)
+  )
+
+
+  ; main
+
+  ; if our value is not an odd amount then we are invalid
+  ; this calculates my_innerpuzhash and passes all values to stager_one
+  (if (logand my_amount 1)
+    (stager_one SINGLETON_STRUCT lineage_proof (sha256tree1 INNER_PUZZLE) my_amount INNER_PUZZLE inner_solution)
+    (x)
+  )
+)

--- a/resources/tests/usecheck-fail/singleton_truths.clib
+++ b/resources/tests/usecheck-fail/singleton_truths.clib
@@ -1,0 +1,29 @@
+(
+  ;; (defun-inline truth_data_to_truth_struct (my_id full_puzhash innerpuzhash my_amount lineage_proof singleton_struct) (c (c my_id  full_puzhash) (c (c innerpuzhash my_amount) (c lineage_proof singleton_struct))))
+  (defun-inline truth_data_to_truth_struct (my_id full_puzhash innerpuzhash my_amount lineage_proof singleton_struct) (c (c my_id  full_puzhash) (c (c innerpuzhash my_amount) (c () singleton_struct))))
+
+  (defun-inline my_id_truth (Truths) (f (f Truths)))
+  (defun-inline my_full_puzzle_hash_truth (Truths) (r (f Truths)))
+  (defun-inline my_inner_puzzle_hash_truth (Truths) (f (f (r Truths))))
+  (defun-inline my_amount_truth (Truths) (r (f (r Truths))))
+  (defun-inline my_lineage_proof_truth (Truths) (f (r (r Truths))))
+  (defun-inline singleton_struct_truth (Truths) (r (r (r Truths))))
+
+  (defun-inline singleton_mod_hash_truth (Truths) (f (singleton_struct_truth Truths)))
+  (defun-inline singleton_launcher_id_truth (Truths) (f (r (singleton_struct_truth Truths))))
+  (defun-inline singleton_launcher_puzzle_hash_truth (Truths) (f (r (r (singleton_struct_truth Truths)))))
+
+  (defun-inline parent_info_for_lineage_proof (lineage_proof) ())
+  (defun-inline puzzle_hash_for_lineage_proof (lineage_proof) ())
+  (defun-inline amount_for_lineage_proof (lineage_proof) ())
+  (defun-inline is_not_eve_proof (lineage_proof) ())
+  (defun-inline parent_info_for_eve_proof (lineage_proof) ())
+  (defun-inline amount_for_eve_proof (lineage_proof) ())
+
+;;  (defun-inline parent_info_for_lineage_proof (lineage_proof) (f lineage_proof))
+;;  (defun-inline puzzle_hash_for_lineage_proof (lineage_proof) (f (r lineage_proof)))
+;;  (defun-inline amount_for_lineage_proof (lineage_proof) (f (r (r lineage_proof))))
+;;  (defun-inline is_not_eve_proof (lineage_proof) (r (r lineage_proof)))
+;;  (defun-inline parent_info_for_eve_proof (lineage_proof) (f lineage_proof))
+;;  (defun-inline amount_for_eve_proof (lineage_proof) (f (r lineage_proof)))
+)

--- a/resources/tests/usecheck-work/singleton_truths.clib
+++ b/resources/tests/usecheck-work/singleton_truths.clib
@@ -1,0 +1,21 @@
+(
+  (defun-inline truth_data_to_truth_struct (my_id full_puzhash innerpuzhash my_amount lineage_proof singleton_struct) (c (c my_id  full_puzhash) (c (c innerpuzhash my_amount) (c lineage_proof singleton_struct))))
+
+  (defun-inline my_id_truth (Truths) (f (f Truths)))
+  (defun-inline my_full_puzzle_hash_truth (Truths) (r (f Truths)))
+  (defun-inline my_inner_puzzle_hash_truth (Truths) (f (f (r Truths))))
+  (defun-inline my_amount_truth (Truths) (r (f (r Truths))))
+  (defun-inline my_lineage_proof_truth (Truths) (f (r (r Truths))))
+  (defun-inline singleton_struct_truth (Truths) (r (r (r Truths))))
+
+  (defun-inline singleton_mod_hash_truth (Truths) (f (singleton_struct_truth Truths)))
+  (defun-inline singleton_launcher_id_truth (Truths) (f (r (singleton_struct_truth Truths))))
+  (defun-inline singleton_launcher_puzzle_hash_truth (Truths) (f (r (r (singleton_struct_truth Truths)))))
+
+  (defun-inline parent_info_for_lineage_proof (lineage_proof) (f lineage_proof))
+  (defun-inline puzzle_hash_for_lineage_proof (lineage_proof) (f (r lineage_proof)))
+  (defun-inline amount_for_lineage_proof (lineage_proof) (f (r (r lineage_proof))))
+  (defun-inline is_not_eve_proof (lineage_proof) (r (r lineage_proof)))
+  (defun-inline parent_info_for_eve_proof (lineage_proof) (f lineage_proof))
+  (defun-inline amount_for_eve_proof (lineage_proof) (f (r lineage_proof)))
+)

--- a/src/classic/clvm_tools/cmds.rs
+++ b/src/classic/clvm_tools/cmds.rs
@@ -707,6 +707,7 @@ pub fn launch_tool(
 
     let dpr;
     let run_program: Rc<dyn TRunProgram>;
+    let mut search_paths = Vec::new();
     match parsedArgs.get("include") {
         Some(ArgumentValue::ArgArray(v)) => {
             let mut bare_paths = Vec::with_capacity(v.len());
@@ -717,6 +718,7 @@ pub fn launch_tool(
                 }
             }
             let special_runner = run_program_for_search_paths(&bare_paths);
+            search_paths = bare_paths;
             dpr = special_runner.clone();
             run_program = special_runner;
         }
@@ -867,7 +869,8 @@ pub fn launch_tool(
             .as_ref()
             .map(|x| x.clone())
             .unwrap_or_else(|| "*command*".to_string());
-        let opts = Rc::new(DefaultCompilerOpts::new(&use_filename));
+        let opts = Rc::new(DefaultCompilerOpts::new(&use_filename)).
+            set_search_paths(&search_paths);
         match check_unused(opts, &input_program) {
             Ok((success, output)) => {
                 stderr_output(output);
@@ -895,6 +898,7 @@ pub fn launch_tool(
         let use_filename = input_file.unwrap_or_else(|| "*command*".to_string());
         let opts = Rc::new(DefaultCompilerOpts::new(&use_filename))
             .set_optimize(do_optimize)
+            .set_search_paths(&search_paths)
             .set_frontend_opt(dialect > 21);
         let mut symbol_table = HashMap::new();
 

--- a/src/classic/clvm_tools/cmds.rs
+++ b/src/classic/clvm_tools/cmds.rs
@@ -869,8 +869,7 @@ pub fn launch_tool(
             .as_ref()
             .map(|x| x.clone())
             .unwrap_or_else(|| "*command*".to_string());
-        let opts = Rc::new(DefaultCompilerOpts::new(&use_filename)).
-            set_search_paths(&search_paths);
+        let opts = Rc::new(DefaultCompilerOpts::new(&use_filename)).set_search_paths(&search_paths);
         match check_unused(opts, &input_program) {
             Ok((success, output)) => {
                 stderr_output(output);

--- a/src/classic/clvm_tools/cmds.rs
+++ b/src/classic/clvm_tools/cmds.rs
@@ -28,7 +28,7 @@ use crate::classic::clvm::KEYWORD_FROM_ATOM;
 use crate::classic::clvm_tools::binutils::{assemble_from_ir, disassemble, disassemble_with_kw};
 use crate::classic::clvm_tools::clvmc::detect_modern;
 use crate::classic::clvm_tools::debug::{
-    check_unused, trace_pre_eval, trace_to_table, trace_to_text
+    check_unused, trace_pre_eval, trace_to_table, trace_to_text,
 };
 use crate::classic::clvm_tools::ir::reader::read_ir;
 use crate::classic::clvm_tools::sha256tree::sha256tree;
@@ -238,13 +238,17 @@ impl ArgumentValueConv for StageImport {
 pub fn run(args: &Vec<String>) {
     let mut s = Stream::new(None);
     launch_tool(&mut s, args, &"run".to_string(), 2);
-    io::stdout().write_all(s.get_value().data()).expect("stdout");
+    io::stdout()
+        .write_all(s.get_value().data())
+        .expect("stdout");
 }
 
 pub fn brun(args: &Vec<String>) {
     let mut s = Stream::new(None);
     launch_tool(&mut s, args, &"brun".to_string(), 0);
-    io::stdout().write_all(s.get_value().data()).expect("stdout");
+    io::stdout()
+        .write_all(s.get_value().data())
+        .expect("stdout");
 }
 
 pub fn cldb(args: &Vec<String>) {
@@ -675,7 +679,9 @@ pub fn launch_tool(
             vec!["--check-unused-args".to_string()],
             Argument::new()
                 .set_action(TArgOptionAction::StoreTrue)
-                .set_help("check for unused uncurried parameters (by convention lower case)".to_string())
+                .set_help(
+                    "check for unused uncurried parameters (by convention lower case)".to_string(),
+                ),
         );
     }
 
@@ -839,11 +845,13 @@ pub fn launch_tool(
     }
 
     // Add unused check.
-    let do_check_unused = parsedArgs.get("check_unused_args").
-        map(|a| match a {
+    let do_check_unused = parsedArgs
+        .get("check_unused_args")
+        .map(|a| match a {
             ArgumentValue::ArgBool(true) => true,
-            _ => false
-        }).unwrap_or_else(|| false);
+            _ => false,
+        })
+        .unwrap_or_else(|| false);
 
     let dialect = input_sexp.and_then(|i| detect_modern(&mut allocator, i));
     let mut stderr_output = |s| {
@@ -855,13 +863,18 @@ pub fn launch_tool(
     };
 
     if do_check_unused {
-        let use_filename = input_file.as_ref().map(|x| x.clone()).unwrap_or_else(|| "*command*".to_string());
+        let use_filename = input_file
+            .as_ref()
+            .map(|x| x.clone())
+            .unwrap_or_else(|| "*command*".to_string());
         let opts = Rc::new(DefaultCompilerOpts::new(&use_filename));
         match check_unused(opts, &input_program) {
             Ok((success, output)) => {
                 stderr_output(output);
-                if !success { return; }
-            },
+                if !success {
+                    return;
+                }
+            }
             Err(e) => {
                 stderr_output(format!("{}: {}\n", e.0.to_string(), e.1));
                 return;

--- a/src/classic/clvm_tools/debug.rs
+++ b/src/classic/clvm_tools/debug.rs
@@ -4,12 +4,18 @@ use std::rc::Rc;
 use clvm_rs::allocator::{Allocator, NodePtr, SExp};
 use clvm_rs::reduction::EvalErr;
 
-use crate::classic::clvm::__type_compatibility__::Stream;
+use crate::classic::clvm::__type_compatibility__::{Stream, Bytes, BytesFromType};
 use crate::classic::clvm::serialize::sexp_to_stream;
 use crate::classic::clvm::sexp::{enlist, mapM, proper_list, rest};
 
 use crate::classic::clvm_tools::sha256tree::sha256tree;
 use crate::classic::clvm_tools::stages::stage_0::TRunProgram;
+
+use crate::compiler::comptypes::{CompilerOpts, CompileErr};
+use crate::compiler::sexp::parse_sexp;
+use crate::compiler::srcloc::Srcloc;
+use crate::compiler::frontend::frontend;
+use crate::compiler::usecheck::check_parameters_used_compileform;
 
 // export const PRELUDE = `<html>
 // <head>
@@ -252,5 +258,26 @@ pub fn trace_pre_eval(
             let _ = append_log(allocator, log_entry);
             Ok(Some(log_entry))
         }
+    }
+}
+
+pub fn check_unused(
+    opts: Rc<dyn CompilerOpts>,
+    input_program: &String,
+) -> Result<(bool, String), CompileErr> {
+    let mut output: Stream = Stream::new(None);
+    let pre_forms =
+        parse_sexp(Srcloc::start(&opts.filename()), input_program).map_err(|e| CompileErr(e.0, e.1))?;
+    let g = frontend(opts.clone(), pre_forms)?;
+    let unused = check_parameters_used_compileform(opts, Rc::new(g))?;
+
+    if !unused.is_empty() {
+        output.write_string(format!("unused arguments detected at the mod level (lower case arguments are considered uncurried by convention)\n"));
+        for s in unused.iter() {
+            output.write_string(format!(" - {}\n", Bytes::new(Some(BytesFromType::Raw(s.clone()))).decode()));
+        }
+        Ok((false, output.get_value().decode()))
+    } else {
+        Ok((true, output.get_value().decode()))
     }
 }

--- a/src/classic/clvm_tools/stages/stage_2/inline.rs
+++ b/src/classic/clvm_tools/stages/stage_2/inline.rs
@@ -1,5 +1,5 @@
 use crate::classic::clvm::__type_compatibility__::{bi_one, bi_zero};
-use crate::classic::clvm::sexp::{enlist, first, flatten, foldM, mapM, non_nil, proper_list, rest};
+use crate::classic::clvm::sexp::{enlist, proper_list};
 use crate::compiler::gensym::gensym;
 use crate::util::Number;
 use clvm_rs::allocator::{Allocator, NodePtr, SExp};

--- a/src/compiler/codegen.rs
+++ b/src/compiler/codegen.rs
@@ -287,6 +287,20 @@ fn codegen_to_sexp(opts: Rc<dyn CompilerOpts>, compiler: &PrimaryCodegen) -> SEx
     )
 }
 
+fn get_prim(
+    loc: Srcloc,
+    prims: Rc<HashMap<Vec<u8>, Rc<SExp>>>,
+    name: &Vec<u8>
+) -> Option<Rc<SExp>> {
+    if let Some(p) = prims.get(name) { return Some(p.clone()); }
+    let myatom = SExp::Atom(loc, name.clone());
+    for kv in prims.iter() {
+        let val_borrowed: &SExp = kv.1.borrow();
+        if val_borrowed == &myatom { return Some(Rc::new(myatom)); }
+    }
+    return None;
+}
+
 pub fn get_callable(
     _opts: Rc<dyn CompilerOpts>,
     compiler: &PrimaryCodegen,
@@ -298,7 +312,7 @@ pub fn get_callable(
             let macro_def = compiler.macros.get(name);
             let inline = compiler.inlines.get(name);
             let defun = create_name_lookup(compiler, l.clone(), name);
-            let prim = compiler.prims.get(name);
+            let prim = get_prim(l.clone(), compiler.prims.clone(), name);
             let atom_is_com = *name == "com".as_bytes().to_vec();
             let atom_is_at = *name == "@".as_bytes().to_vec();
             match (macro_def, inline, defun, prim, atom_is_com, atom_is_at) {

--- a/src/compiler/codegen.rs
+++ b/src/compiler/codegen.rs
@@ -290,13 +290,17 @@ fn codegen_to_sexp(opts: Rc<dyn CompilerOpts>, compiler: &PrimaryCodegen) -> SEx
 fn get_prim(
     loc: Srcloc,
     prims: Rc<HashMap<Vec<u8>, Rc<SExp>>>,
-    name: &Vec<u8>
+    name: &Vec<u8>,
 ) -> Option<Rc<SExp>> {
-    if let Some(p) = prims.get(name) { return Some(p.clone()); }
+    if let Some(p) = prims.get(name) {
+        return Some(p.clone());
+    }
     let myatom = SExp::Atom(loc, name.clone());
     for kv in prims.iter() {
         let val_borrowed: &SExp = kv.1.borrow();
-        if val_borrowed == &myatom { return Some(Rc::new(myatom)); }
+        if val_borrowed == &myatom {
+            return Some(Rc::new(myatom));
+        }
     }
     return None;
 }

--- a/src/compiler/evaluate.rs
+++ b/src/compiler/evaluate.rs
@@ -528,14 +528,14 @@ fn compute_hash_of_apply(body: Rc<BodyForm>, env: Rc<BodyForm>) -> Vec<u8> {
 
 fn flatten_expression_to_names_inner(collection: &mut HashSet<Vec<u8>>, expr: Rc<SExp>) {
     match expr.borrow() {
-        SExp::Cons(_,a,b) => {
+        SExp::Cons(_, a, b) => {
             flatten_expression_to_names_inner(collection, a.clone());
             flatten_expression_to_names_inner(collection, b.clone());
-        },
-        SExp::Atom(_,a) => {
+        }
+        SExp::Atom(_, a) => {
             collection.insert(a.clone());
-        },
-        _ => { }
+        }
+        _ => {}
     }
 }
 
@@ -547,8 +547,14 @@ fn flatten_expression_to_names(expr: Rc<SExp>) -> Rc<BodyForm> {
         transformed.push(a.clone());
     }
     transformed.sort();
-    let mut call_vec: Vec<Rc<BodyForm>> = transformed.iter().map(|x| Rc::new(BodyForm::Value(SExp::Atom(expr.loc(), x.clone())))).collect();
-    call_vec.insert(0, Rc::new(BodyForm::Value(SExp::Atom(expr.loc(), vec![b'+']))));
+    let mut call_vec: Vec<Rc<BodyForm>> = transformed
+        .iter()
+        .map(|x| Rc::new(BodyForm::Value(SExp::Atom(expr.loc(), x.clone()))))
+        .collect();
+    call_vec.insert(
+        0,
+        Rc::new(BodyForm::Value(SExp::Atom(expr.loc(), vec![b'+']))),
+    );
     Rc::new(BodyForm::Call(expr.loc(), call_vec))
 }
 
@@ -783,10 +789,13 @@ impl Evaluator {
                 return Ok(present.clone());
             }
 
-            visited.insert(where_from_vec.clone(), Rc::new(BodyForm::Call(maybe_condition.loc(), vec![
-                x_head.clone(),
-                cond.clone()
-            ])));
+            visited.insert(
+                where_from_vec.clone(),
+                Rc::new(BodyForm::Call(
+                    maybe_condition.loc(),
+                    vec![x_head.clone(), cond.clone()],
+                )),
+            );
 
             let surrogate_apply_true = self.chase_apply(
                 allocator,
@@ -816,8 +825,8 @@ impl Evaluator {
                     x_head,
                     flatten_expression_to_names(cond.to_sexp()),
                     flatten_expression_to_names(surrogate_apply_true?.to_sexp()),
-                    flatten_expression_to_names(surrogate_apply_false?.to_sexp())
-                ]
+                    flatten_expression_to_names(surrogate_apply_false?.to_sexp()),
+                ],
             ));
 
             return Ok(res);

--- a/src/compiler/evaluate.rs
+++ b/src/compiler/evaluate.rs
@@ -274,6 +274,7 @@ pub fn dequote(l: Srcloc, exp: Rc<BodyForm>) -> Result<Rc<SExp>, CompileErr> {
     }
 }
 
+/*
 fn show_env(env: &HashMap<Vec<u8>, Rc<BodyForm>>) {
     let loc = Srcloc::start(&"*env*".to_string());
     for kv in env.iter() {
@@ -284,6 +285,7 @@ fn show_env(env: &HashMap<Vec<u8>, Rc<BodyForm>>) {
         );
     }
 }
+*/
 
 pub fn first_of_alist(lst: Rc<SExp>) -> Result<Rc<SExp>, CompileErr> {
     match lst.borrow() {
@@ -301,16 +303,6 @@ pub fn second_of_alist(lst: Rc<SExp>) -> Result<Rc<SExp>, CompileErr> {
         _ => Err(CompileErr(
             lst.loc(),
             format!("No second element of {}", lst.to_string()),
-        )),
-    }
-}
-
-fn third_of_alist(lst: Rc<SExp>) -> Result<Rc<SExp>, CompileErr> {
-    match lst.borrow() {
-        SExp::Cons(_, _, r) => second_of_alist(r.clone()),
-        _ => Err(CompileErr(
-            lst.loc(),
-            format!("No third element of {}", lst.to_string()),
         )),
     }
 }
@@ -488,7 +480,7 @@ fn promote_program_to_bodyform(program: Rc<SExp>, env: Rc<BodyForm>) -> Result<R
 fn match_i_op(
     candidate: Rc<BodyForm>
 ) -> Option<(Rc<BodyForm>, Rc<BodyForm>, Rc<BodyForm>)> {
-    if let BodyForm::Call(l, cvec) = candidate.borrow() {
+    if let BodyForm::Call(_, cvec) = candidate.borrow() {
         if cvec.len() != 4 { return None; }
         if let BodyForm::Value(atom) = cvec[0].borrow() {
             if is_i_atom(Rc::new(atom.clone())) {
@@ -525,7 +517,7 @@ fn compute_hash_of_apply(
     body: Rc<BodyForm>,
     env: Rc<BodyForm>
 ) -> Vec<u8> {
-    let mut composed =
+    let composed =
         Rc::new(BodyForm::Call(body.loc(), vec![body.clone(), env.clone()]));
     sha256tree(composed.to_sexp())
 }
@@ -852,7 +844,7 @@ impl Evaluator {
         l: Srcloc,
         call_loc: Srcloc,
         call_name: &Vec<u8>,
-        head_expr: Rc<BodyForm>,
+        _head_expr: Rc<BodyForm>,
         parts: &Vec<Rc<BodyForm>>,
         body: Rc<BodyForm>,
         prog_args: Rc<SExp>,

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -16,3 +16,4 @@ pub mod repl;
 pub mod runtypes;
 pub mod sexp;
 pub mod srcloc;
+pub mod usecheck;

--- a/src/compiler/usecheck.rs
+++ b/src/compiler/usecheck.rs
@@ -86,13 +86,16 @@ pub fn check_parameters_used_compileform(
     let runner = Rc::new(DefaultProgramRunner::new());
     let mut replacement_to_original = HashMap::new();
     let base_name = Bytes::new(Some(BytesFromType::Raw(sha256tree(program.to_sexp())))).hex().as_bytes().to_vec();
-    let e = Evaluator::new(opts.clone(), runner.clone(), program.helpers.clone());
+    let e = Evaluator::new(opts.clone(), runner.clone(), program.helpers.clone()).
+        mash_conditions();
+
     produce_env_captures(
         &mut env,
         &mut replacement_to_original,
         base_name,
         program.args.clone()
     );
+
     let result = e.shrink_bodyform(
         &mut allocator,
         program.args.clone(),
@@ -100,6 +103,7 @@ pub fn check_parameters_used_compileform(
         program.exp.clone(),
         false
     )?;
+    println!("shrunk to {}", result.to_sexp().to_string());
 
     remove_present_atoms(
         &mut replacement_to_original,

--- a/src/compiler/usecheck.rs
+++ b/src/compiler/usecheck.rs
@@ -1,4 +1,4 @@
-extern crate clvm_rust as clvm_rs;
+extern crate clvmr as clvm_rs;
 
 use std::borrow::Borrow;
 use std::collections::{HashMap, HashSet};

--- a/src/compiler/usecheck.rs
+++ b/src/compiler/usecheck.rs
@@ -1,0 +1,114 @@
+extern crate clvm_rust as clvm_rs;
+
+use std::borrow::Borrow;
+use std::collections::{HashMap, HashSet};
+use std::rc::Rc;
+
+use clvm_rs::allocator::Allocator;
+
+use crate::classic::clvm::__type_compatibility__::{
+    Bytes,
+    BytesFromType
+};
+use crate::classic::clvm_tools::stages::stage_0::{
+    DefaultProgramRunner
+};
+
+use crate::compiler::clvm::sha256tree;
+use crate::compiler::comptypes::{
+    CompileErr,
+    CompileForm,
+    CompilerOpts,
+    BodyForm
+};
+use crate::compiler::evaluate::Evaluator;
+use crate::compiler::sexp::SExp;
+use crate::util::u8_from_number;
+
+// We consider lower case atoms as uncurried by convention.
+fn consider_as_uncurried(v: &Vec<u8>) -> bool {
+    v.len() > 0 && v[0] >= b'a' && v[0] <= b'z'
+}
+
+fn produce_env_captures(
+    envmap: &mut HashMap<Vec<u8>, Rc<BodyForm>>,
+    envlist: &mut HashMap<Vec<u8>, Vec<u8>>,
+    base_name: Vec<u8>,
+    args: Rc<SExp>
+) {
+    match args.borrow() {
+        SExp::Cons(_,a,b) => {
+            produce_env_captures(envmap, envlist, base_name.clone(), a.clone());
+            produce_env_captures(envmap, envlist, base_name, b.clone());
+        },
+        SExp::Atom(l,a) => {
+            if consider_as_uncurried(a) {
+                let mut new_name = a.clone();
+                new_name.append(&mut "_$_".as_bytes().to_vec());
+                new_name.append(&mut base_name.clone());
+                envmap.insert(a.clone(), Rc::new(BodyForm::Value(SExp::Atom(l.clone(), new_name.clone()))));
+                envlist.insert(new_name, a.clone());
+            }
+        },
+        _ => { }
+    }
+}
+
+fn remove_present_atoms(
+    envlist: &mut HashMap<Vec<u8>, Vec<u8>>,
+    args: Rc<SExp>
+) {
+    match args.borrow() {
+        SExp::Cons(_,a,b) => {
+            remove_present_atoms(envlist, a.clone());
+            remove_present_atoms(envlist, b.clone());
+        },
+        SExp::Atom(_,b) => {
+            envlist.remove(b);
+        },
+        // Appearing in the output, all atom types are equivalent.
+        SExp::QuotedString(_,_,b) => {
+            envlist.remove(b);
+        },
+        SExp::Integer(_,i) => {
+            envlist.remove(&u8_from_number(i.clone()));
+        },
+        _ => { }
+    }
+}
+
+pub fn check_parameters_used_compileform(
+    opts: Rc<dyn CompilerOpts>,
+    program: Rc<CompileForm>
+) -> Result<HashSet<Vec<u8>>, CompileErr> {
+    let mut allocator = Allocator::new();
+    let mut env = HashMap::new();
+    let runner = Rc::new(DefaultProgramRunner::new());
+    let mut replacement_to_original = HashMap::new();
+    let base_name = Bytes::new(Some(BytesFromType::Raw(sha256tree(program.to_sexp())))).hex().as_bytes().to_vec();
+    let e = Evaluator::new(opts.clone(), runner.clone(), program.helpers.clone());
+    produce_env_captures(
+        &mut env,
+        &mut replacement_to_original,
+        base_name,
+        program.args.clone()
+    );
+    let result = e.shrink_bodyform(
+        &mut allocator,
+        program.args.clone(),
+        &env,
+        program.exp.clone(),
+        false
+    )?;
+
+    remove_present_atoms(
+        &mut replacement_to_original,
+        result.to_sexp()
+    );
+
+    let mut result_set = HashSet::new();
+    for kv in replacement_to_original.iter() {
+        result_set.insert(kv.1.clone());
+    }
+    Ok(result_set)
+}

--- a/src/compiler/usecheck.rs
+++ b/src/compiler/usecheck.rs
@@ -103,7 +103,6 @@ pub fn check_parameters_used_compileform(
         program.exp.clone(),
         false
     )?;
-    println!("shrunk to {}", result.to_sexp().to_string());
 
     remove_present_atoms(
         &mut replacement_to_original,

--- a/src/compiler/usecheck.rs
+++ b/src/compiler/usecheck.rs
@@ -6,21 +6,11 @@ use std::rc::Rc;
 
 use clvm_rs::allocator::Allocator;
 
-use crate::classic::clvm::__type_compatibility__::{
-    Bytes,
-    BytesFromType
-};
-use crate::classic::clvm_tools::stages::stage_0::{
-    DefaultProgramRunner
-};
+use crate::classic::clvm::__type_compatibility__::{Bytes, BytesFromType};
+use crate::classic::clvm_tools::stages::stage_0::DefaultProgramRunner;
 
 use crate::compiler::clvm::sha256tree;
-use crate::compiler::comptypes::{
-    CompileErr,
-    CompileForm,
-    CompilerOpts,
-    BodyForm
-};
+use crate::compiler::comptypes::{BodyForm, CompileErr, CompileForm, CompilerOpts};
 use crate::compiler::evaluate::Evaluator;
 use crate::compiler::sexp::SExp;
 use crate::util::u8_from_number;
@@ -34,66 +24,68 @@ fn produce_env_captures(
     envmap: &mut HashMap<Vec<u8>, Rc<BodyForm>>,
     envlist: &mut HashMap<Vec<u8>, Vec<u8>>,
     base_name: Vec<u8>,
-    args: Rc<SExp>
+    args: Rc<SExp>,
 ) {
     match args.borrow() {
-        SExp::Cons(_,a,b) => {
+        SExp::Cons(_, a, b) => {
             produce_env_captures(envmap, envlist, base_name.clone(), a.clone());
             produce_env_captures(envmap, envlist, base_name, b.clone());
-        },
-        SExp::Atom(l,a) => {
+        }
+        SExp::Atom(l, a) => {
             if consider_as_uncurried(a) {
                 let mut new_name = a.clone();
                 new_name.append(&mut "_$_".as_bytes().to_vec());
                 new_name.append(&mut base_name.clone());
-                envmap.insert(a.clone(), Rc::new(BodyForm::Value(SExp::Atom(l.clone(), new_name.clone()))));
+                envmap.insert(
+                    a.clone(),
+                    Rc::new(BodyForm::Value(SExp::Atom(l.clone(), new_name.clone()))),
+                );
                 envlist.insert(new_name, a.clone());
             }
-        },
-        _ => { }
+        }
+        _ => {}
     }
 }
 
-fn remove_present_atoms(
-    envlist: &mut HashMap<Vec<u8>, Vec<u8>>,
-    args: Rc<SExp>
-) {
+fn remove_present_atoms(envlist: &mut HashMap<Vec<u8>, Vec<u8>>, args: Rc<SExp>) {
     match args.borrow() {
-        SExp::Cons(_,a,b) => {
+        SExp::Cons(_, a, b) => {
             remove_present_atoms(envlist, a.clone());
             remove_present_atoms(envlist, b.clone());
-        },
-        SExp::Atom(_,b) => {
+        }
+        SExp::Atom(_, b) => {
             envlist.remove(b);
-        },
+        }
         // Appearing in the output, all atom types are equivalent.
-        SExp::QuotedString(_,_,b) => {
+        SExp::QuotedString(_, _, b) => {
             envlist.remove(b);
-        },
-        SExp::Integer(_,i) => {
+        }
+        SExp::Integer(_, i) => {
             envlist.remove(&u8_from_number(i.clone()));
-        },
-        _ => { }
+        }
+        _ => {}
     }
 }
 
 pub fn check_parameters_used_compileform(
     opts: Rc<dyn CompilerOpts>,
-    program: Rc<CompileForm>
+    program: Rc<CompileForm>,
 ) -> Result<HashSet<Vec<u8>>, CompileErr> {
     let mut allocator = Allocator::new();
     let mut env = HashMap::new();
     let runner = Rc::new(DefaultProgramRunner::new());
     let mut replacement_to_original = HashMap::new();
-    let base_name = Bytes::new(Some(BytesFromType::Raw(sha256tree(program.to_sexp())))).hex().as_bytes().to_vec();
-    let e = Evaluator::new(opts.clone(), runner.clone(), program.helpers.clone()).
-        mash_conditions();
+    let base_name = Bytes::new(Some(BytesFromType::Raw(sha256tree(program.to_sexp()))))
+        .hex()
+        .as_bytes()
+        .to_vec();
+    let e = Evaluator::new(opts.clone(), runner.clone(), program.helpers.clone()).mash_conditions();
 
     produce_env_captures(
         &mut env,
         &mut replacement_to_original,
         base_name,
-        program.args.clone()
+        program.args.clone(),
     );
 
     let result = e.shrink_bodyform(
@@ -101,13 +93,10 @@ pub fn check_parameters_used_compileform(
         program.args.clone(),
         &env,
         program.exp.clone(),
-        false
+        false,
     )?;
 
-    remove_present_atoms(
-        &mut replacement_to_original,
-        result.to_sexp()
-    );
+    remove_present_atoms(&mut replacement_to_original, result.to_sexp());
 
     let mut result_set = HashSet::new();
     for kv in replacement_to_original.iter() {

--- a/src/compiler/usecheck.rs
+++ b/src/compiler/usecheck.rs
@@ -32,16 +32,14 @@ fn produce_env_captures(
             produce_env_captures(envmap, envlist, base_name, b.clone());
         }
         SExp::Atom(l, a) => {
-            if consider_as_uncurried(a) {
-                let mut new_name = a.clone();
-                new_name.append(&mut "_$_".as_bytes().to_vec());
-                new_name.append(&mut base_name.clone());
-                envmap.insert(
-                    a.clone(),
-                    Rc::new(BodyForm::Value(SExp::Atom(l.clone(), new_name.clone()))),
-                );
-                envlist.insert(new_name, a.clone());
-            }
+            let mut new_name = a.clone();
+            new_name.append(&mut "_$_".as_bytes().to_vec());
+            new_name.append(&mut base_name.clone());
+            envmap.insert(
+                a.clone(),
+                Rc::new(BodyForm::Value(SExp::Atom(l.clone(), new_name.clone()))),
+            );
+            envlist.insert(new_name, a.clone());
         }
         _ => {}
     }
@@ -100,7 +98,9 @@ pub fn check_parameters_used_compileform(
 
     let mut result_set = HashSet::new();
     for kv in replacement_to_original.iter() {
-        result_set.insert(kv.1.clone());
+        if consider_as_uncurried(kv.0) {
+            result_set.insert(kv.1.clone());
+        }
     }
     Ok(result_set)
 }

--- a/src/tests/compiler/evaluate.rs
+++ b/src/tests/compiler/evaluate.rs
@@ -8,7 +8,6 @@ use crate::compiler::compiler::DefaultCompilerOpts;
 use crate::compiler::comptypes::{CompileErr, CompilerOpts};
 use crate::compiler::evaluate::Evaluator;
 use crate::compiler::frontend::{from_clvm, frontend};
-use crate::compiler::prims::prim_map;
 use crate::compiler::sexp::{parse_sexp, SExp};
 use crate::compiler::srcloc::Srcloc;
 
@@ -72,9 +71,6 @@ fn test_basic_expand_macro_3() {
 }
 
 fn convert_clvm_to_chialisp(s: String) -> Result<Rc<SExp>, CompileErr> {
-    let runner = Rc::new(DefaultProgramRunner::new());
-    let prims = prim_map();
-    let opts = Rc::new(DefaultCompilerOpts::new(&"*program*".to_string()));
     let loc = Srcloc::start(&"*program*".to_string());
     parse_sexp(loc.clone(), &s)
         .map_err(|e| {

--- a/src/tests/compiler/mod.rs
+++ b/src/tests/compiler/mod.rs
@@ -8,6 +8,7 @@ mod clvm;
 mod compiler;
 mod evaluate;
 mod repl;
+mod usecheck;
 
 #[test]
 fn test_sexp_parse_print() {

--- a/src/tests/compiler/usecheck.rs
+++ b/src/tests/compiler/usecheck.rs
@@ -1,0 +1,3 @@
+fn check_argument_use(code: String) -> HashSet<String> {
+    todo!();
+}

--- a/src/tests/compiler/usecheck.rs
+++ b/src/tests/compiler/usecheck.rs
@@ -1,3 +1,137 @@
-fn check_argument_use(code: String) -> HashSet<String> {
-    todo!();
+use std::rc::Rc;
+
+use clvm_rust::allocator::Allocator;
+
+use crate::classic::clvm::__type_compatibility__::{Bytes, BytesFromType};
+use crate::classic::clvm_tools::stages::stage_0::DefaultProgramRunner;
+use crate::compiler::compiler::DefaultCompilerOpts;
+use crate::compiler::comptypes::{CompileErr, CompilerOpts};
+use crate::compiler::frontend::frontend;
+use crate::compiler::sexp::parse_sexp;
+use crate::compiler::srcloc::Srcloc;
+use crate::compiler::usecheck::check_parameters_used_compileform;
+
+fn check_argument_use(input_program: String) -> Vec<String> {
+    let mut allocator = Allocator::new();
+    let runner = Rc::new(DefaultProgramRunner::new());
+    let opts: Rc<dyn CompilerOpts> =
+        Rc::new(DefaultCompilerOpts::new(&"*test*".to_string()));
+    let pre_forms =
+        parse_sexp(Srcloc::start(&opts.filename()), &input_program).
+        map_err(|e| CompileErr(e.0, e.1)).expect("should parse");
+    let g = frontend(opts.clone(), pre_forms).expect("should pass frontend");
+    let set = check_parameters_used_compileform(opts, Rc::new(g)).
+        expect("should be able to determine unused vars");
+    let mut result = Vec::new();
+    for x in set.iter() {
+        result.push(Bytes::new(Some(BytesFromType::Raw(x.clone()))).decode());
+    }
+    result.sort();
+    result
+}
+
+fn empty_vec() -> Vec<String> { vec![] }
+
+#[test]
+fn check_unused_base_case_0() {
+    assert_eq!(
+        check_argument_use("(mod () (x))".to_string()),
+        empty_vec()
+    );
+}
+
+#[test]
+fn check_unused_base_case_1() {
+    assert_eq!(
+        check_argument_use("(mod (_) (x))".to_string()),
+        empty_vec()
+    );
+}
+
+#[test]
+fn check_unused_base_case_2() {
+    assert_eq!(
+        check_argument_use("(mod (A) (x))".to_string()),
+        empty_vec()
+    );
+}
+
+#[test]
+fn check_unused_base_case_3() {
+    assert_eq!(
+        check_argument_use("(mod (a) (x))".to_string()),
+        vec!["a".to_string()]
+    );
+}
+
+#[test]
+fn check_unused_base_case_4() {
+    assert_eq!(
+        check_argument_use("(mod (a) (x a))".to_string()),
+        empty_vec()
+    );
+}
+
+#[test]
+fn check_unused_fun_1() {
+    assert_eq!(
+        check_argument_use("(mod (a) (defun F (g) (+ g 1)) (F a))".to_string()),
+        empty_vec()
+    );
+}
+
+#[test]
+fn check_unused_fun_2() {
+    assert_eq!(
+        check_argument_use("(mod (a) (defun F (g) (+ 2 3)) (F a))".to_string()),
+        vec!["a".to_string()]
+    );
+}
+
+#[test]
+fn check_unused_fun_if_1() {
+    assert_eq!(
+        check_argument_use("(mod (a) (defun F (g h) (if g (+ h 1) ())) (F () a))".to_string()),
+        vec!["a".to_string()]
+    );
+}
+
+#[test]
+fn check_unused_fun_if_2() {
+    assert_eq!(
+        check_argument_use("(mod (a) (defun F (g h) (if g (+ h 1) ())) (F 1 a))".to_string()),
+        empty_vec()
+    );
+}
+
+#[test]
+fn check_unused_fun_rec_1() {
+    assert_eq!(
+        check_argument_use("(mod (a) (defun F (X) (if X (F (- X 1)) ())) (F a))".to_string()),
+        empty_vec()
+    );
+}
+
+#[test]
+fn check_unused_fun_rec_2() {
+    assert_eq!(
+        check_argument_use("(mod (a) (defun F (R) (if R (F (- R 1)) R)) (F a))".to_string()),
+        empty_vec()
+    );
+}
+
+#[test]
+fn check_unused_fun_rec_3() {
+    assert_eq!(
+        check_argument_use("(mod (a b) (defun F (X Y) (if X (F (- X 1) Y) X)) (F a b))".to_string()),
+        vec!["b".to_string()]
+    );
+}
+
+#[test]
+fn check_unused_fun_rec_4() {
+    assert_eq!(
+        check_argument_use("(mod (a b) (defun G (s t) t) (defun F (a b) (if b (F a (- b 1)) (G a b))) (F a b))".to_string()),
+        vec!["a".to_string()]
+    );
 }

--- a/src/tests/compiler/usecheck.rs
+++ b/src/tests/compiler/usecheck.rs
@@ -149,32 +149,28 @@ fn check_unused_fun_let_1() {
 
 #[test]
 fn verify_use_check_with_singleton_top_layer_fails_when_we_comment_out_all_uses_of_lineage_proof() {
-    let res = do_basic_run(
-        &vec![
-            "run".to_string(),
-            "-i".to_string(),
-            "resources/tests".to_string(),
-            "-i".to_string(),
-            "resources/tests/usecheck-fail".to_string(),
-            "--check-unused-args".to_string(),
-            "resources/tests/singleton_top_layer.clvm".to_string()
-        ]
-    );
+    let res = do_basic_run(&vec![
+        "run".to_string(),
+        "-i".to_string(),
+        "resources/tests".to_string(),
+        "-i".to_string(),
+        "resources/tests/usecheck-fail".to_string(),
+        "--check-unused-args".to_string(),
+        "resources/tests/singleton_top_layer.clvm".to_string(),
+    ]);
     assert_eq!(res, "unused arguments detected at the mod level (lower case arguments are considered uncurried by convention)\n - lineage_proof\n");
 }
 
 #[test]
 fn verify_use_check_with_singleton_top_layer_works() {
-    let res = do_basic_run(
-        &vec![
-            "run".to_string(),
-            "-i".to_string(),
-            "resources/tests".to_string(),
-            "-i".to_string(),
-            "resources/tests/usecheck-work".to_string(),
-            "--check-unused-args".to_string(),
-            "resources/tests/singleton_top_layer.clvm".to_string()
-        ]
-    );
+    let res = do_basic_run(&vec![
+        "run".to_string(),
+        "-i".to_string(),
+        "resources/tests".to_string(),
+        "-i".to_string(),
+        "resources/tests/usecheck-work".to_string(),
+        "--check-unused-args".to_string(),
+        "resources/tests/singleton_top_layer.clvm".to_string(),
+    ]);
     assert!(res.len() > 0 && res.as_bytes()[0] == b'(');
 }

--- a/src/tests/compiler/usecheck.rs
+++ b/src/tests/compiler/usecheck.rs
@@ -1,9 +1,6 @@
 use std::rc::Rc;
 
-use clvm_rust::allocator::Allocator;
-
 use crate::classic::clvm::__type_compatibility__::{Bytes, BytesFromType};
-use crate::classic::clvm_tools::stages::stage_0::DefaultProgramRunner;
 use crate::compiler::compiler::DefaultCompilerOpts;
 use crate::compiler::comptypes::{CompileErr, CompilerOpts};
 use crate::compiler::frontend::frontend;
@@ -12,8 +9,6 @@ use crate::compiler::srcloc::Srcloc;
 use crate::compiler::usecheck::check_parameters_used_compileform;
 
 fn check_argument_use(input_program: String) -> Vec<String> {
-    let mut allocator = Allocator::new();
-    let runner = Rc::new(DefaultProgramRunner::new());
     let opts: Rc<dyn CompilerOpts> =
         Rc::new(DefaultCompilerOpts::new(&"*test*".to_string()));
     let pre_forms =

--- a/src/tests/compiler/usecheck.rs
+++ b/src/tests/compiler/usecheck.rs
@@ -9,14 +9,13 @@ use crate::compiler::srcloc::Srcloc;
 use crate::compiler::usecheck::check_parameters_used_compileform;
 
 fn check_argument_use(input_program: String) -> Vec<String> {
-    let opts: Rc<dyn CompilerOpts> =
-        Rc::new(DefaultCompilerOpts::new(&"*test*".to_string()));
-    let pre_forms =
-        parse_sexp(Srcloc::start(&opts.filename()), &input_program).
-        map_err(|e| CompileErr(e.0, e.1)).expect("should parse");
+    let opts: Rc<dyn CompilerOpts> = Rc::new(DefaultCompilerOpts::new(&"*test*".to_string()));
+    let pre_forms = parse_sexp(Srcloc::start(&opts.filename()), &input_program)
+        .map_err(|e| CompileErr(e.0, e.1))
+        .expect("should parse");
     let g = frontend(opts.clone(), pre_forms).expect("should pass frontend");
-    let set = check_parameters_used_compileform(opts, Rc::new(g)).
-        expect("should be able to determine unused vars");
+    let set = check_parameters_used_compileform(opts, Rc::new(g))
+        .expect("should be able to determine unused vars");
     let mut result = Vec::new();
     for x in set.iter() {
         result.push(Bytes::new(Some(BytesFromType::Raw(x.clone()))).decode());
@@ -25,30 +24,23 @@ fn check_argument_use(input_program: String) -> Vec<String> {
     result
 }
 
-fn empty_vec() -> Vec<String> { vec![] }
+fn empty_vec() -> Vec<String> {
+    vec![]
+}
 
 #[test]
 fn check_unused_base_case_0() {
-    assert_eq!(
-        check_argument_use("(mod () (x))".to_string()),
-        empty_vec()
-    );
+    assert_eq!(check_argument_use("(mod () (x))".to_string()), empty_vec());
 }
 
 #[test]
 fn check_unused_base_case_1() {
-    assert_eq!(
-        check_argument_use("(mod (_) (x))".to_string()),
-        empty_vec()
-    );
+    assert_eq!(check_argument_use("(mod (_) (x))".to_string()), empty_vec());
 }
 
 #[test]
 fn check_unused_base_case_2() {
-    assert_eq!(
-        check_argument_use("(mod (A) (x))".to_string()),
-        empty_vec()
-    );
+    assert_eq!(check_argument_use("(mod (A) (x))".to_string()), empty_vec());
 }
 
 #[test]
@@ -118,7 +110,9 @@ fn check_unused_fun_rec_2() {
 #[test]
 fn check_unused_fun_rec_3() {
     assert_eq!(
-        check_argument_use("(mod (a b) (defun F (X Y) (if X (F (- X 1) Y) X)) (F a b))".to_string()),
+        check_argument_use(
+            "(mod (a b) (defun F (X Y) (if X (F (- X 1) Y) X)) (F a b))".to_string()
+        ),
         vec!["b".to_string()]
     );
 }
@@ -126,7 +120,10 @@ fn check_unused_fun_rec_3() {
 #[test]
 fn check_unused_fun_rec_4() {
     assert_eq!(
-        check_argument_use("(mod (a b) (defun G (s t) t) (defun F (a b) (if b (F a (- b 1)) (G a b))) (F a b))".to_string()),
+        check_argument_use(
+            "(mod (a b) (defun G (s t) t) (defun F (a b) (if b (F a (- b 1)) (G a b))) (F a b))"
+                .to_string()
+        ),
         vec!["a".to_string()]
     );
 }
@@ -134,7 +131,10 @@ fn check_unused_fun_rec_4() {
 #[test]
 fn check_unused_fun_let_1() {
     assert_eq!(
-        check_argument_use("(mod (a) (include *standard-cl-21*) (defun F (x) (let ((s (sha256 x))) 3)) (F a))".to_string()),
+        check_argument_use(
+            "(mod (a) (include *standard-cl-21*) (defun F (x) (let ((s (sha256 x))) 3)) (F a))"
+                .to_string()
+        ),
         vec!["a".to_string()]
     );
 }

--- a/src/tests/compiler/usecheck.rs
+++ b/src/tests/compiler/usecheck.rs
@@ -135,3 +135,11 @@ fn check_unused_fun_rec_4() {
         vec!["a".to_string()]
     );
 }
+
+#[test]
+fn check_unused_fun_let_1() {
+    assert_eq!(
+        check_argument_use("(mod (a) (include *standard-cl-21*) (defun F (x) (let ((s (sha256 x))) 3)) (F a))".to_string()),
+        vec!["a".to_string()]
+    );
+}

--- a/support/recompile_check.py
+++ b/support/recompile_check.py
@@ -21,7 +21,6 @@ recompile_list = [
     'nft_metadata_updater_updateable.clvm',
     'nft_ownership_layer.clvm',
     'nft_ownership_transfer_program_one_way_claim_with_royalties.clvm',
-    'nft_ownership_transfer_program_one_way_claim_with_royalties_new.clvm',
     'nft_state_layer.clvm',
     'p2_conditions.clvm',
     'p2_delegated_conditions.clvm',


### PR DESCRIPTION
This adds a --check-unused-args which causes a run through the repl's evaluator to determine what arguments are actually represented in the behavior of the chialisp program.  If a lower-case (by convention not normally curried) argument is unused along all paths to a result, then the argument will be reported as unused and a program not generated.

This is new and uses some new facilities so should be thought of as a bit experimental for now.