### PR TITLE
Join mainline published clvmr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,8 +125,9 @@ dependencies = [
 
 [[package]]
 name = "clvmr"
-version = "0.1.20"
-source = "git+https://github.com/Chia-Network/clvm_rs?rev=519e7d8bbc490aa9e60514f844f9ccd7af6d8dd2#519e7d8bbc490aa9e60514f844f9ccd7af6d8dd2"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ca2623b5f3aec50a9130d203a8bf93fe203ba180d00517cef29250e99b2620"
 dependencies = [
  "bls12_381",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clvm_tools_rs"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2018"
 authors = ["Art Yerkes <art.yerkes@gmail.com>"]
 description = "tools for working with chialisp language; compiler, repl, python and wasm bindings"
@@ -30,11 +30,10 @@ serde_json = "1.0"
 sha2 = "0.9.5"
 yamlette = "0.0.8"
 tempfile = "3.3.0"
-clvmr = "0.1.20"
+clvmr = "0.1.21"
 
 [patch.crates-io]
 skimmer = { git = "https://github.com/dnsl48/skimmer", rev = "ca914ef624ecf39a75ed7afef10e7838fffe9127" }
-clvmr = { git = "https://github.com/Chia-Network/clvm_rs", rev = "519e7d8bbc490aa9e60514f844f9ccd7af6d8dd2" }
 
 [target.x86_64-apple-darwin]
 rustflags = [


### PR DESCRIPTION
This updates to the current clvmr which exports all necessary types and traits for the classic compiler.