### PR TITLE
20220704 hex constant fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cc971dad342555038de31a76cb3eb3d454a15bc65dac9e3024bbec9fa598cec"
 
 [[package]]
+name = "binascii"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "383d29d513d8764dcdc42ea295d979eb99c3c9f00607b3692cf68a431f7dca72"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,6 +104,7 @@ dependencies = [
 name = "clvm_tools_rs"
 version = "0.1.17"
 dependencies = [
+ "binascii",
  "bls12_381",
  "bytestream",
  "clvmr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "clvm_tools_rs"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "binascii",
  "bls12_381",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ sha2 = "0.9.5"
 yamlette = "0.0.8"
 tempfile = "3.3.0"
 clvmr = "0.1.21"
+binascii = "0.1.4"
 
 [patch.crates-io]
 skimmer = { git = "https://github.com/dnsl48/skimmer", rev = "ca914ef624ecf39a75ed7afef10e7838fffe9127" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clvm_tools_rs"
-version = "0.1.17"
+version = "0.1.18"
 edition = "2018"
 authors = ["Art Yerkes <art.yerkes@gmail.com>"]
 description = "tools for working with chialisp language; compiler, repl, python and wasm bindings"

--- a/src/compiler/sexp.rs
+++ b/src/compiler/sexp.rs
@@ -3,7 +3,7 @@ use std::hash::{Hash, Hasher};
 use std::rc::Rc;
 use std::string::String;
 
-use binascii::{hex2bin, bin2hex};
+use binascii::{bin2hex, hex2bin};
 use num_traits::{zero, Num};
 
 use crate::classic::clvm::__type_compatibility__::{bi_zero, Bytes, BytesFromType};
@@ -155,7 +155,7 @@ fn make_atom(l: Srcloc, v: Vec<u8>) -> SExp {
                 } else {
                     SExp::Integer(l, intval)
                 }
-            },
+            }
             Integral::NotIntegral => SExp::Atom(l, v),
         }
     }
@@ -265,10 +265,14 @@ impl SExp {
                 } else {
                     let vlen = s.len() * 2;
                     let mut outbuf = vec![0; vlen];
-                    bin2hex(s, &mut outbuf).expect("should be able to convert unprintable string to hex");
-                    format!("0x{}", std::str::from_utf8(&outbuf).expect("only hex digits expected"))
+                    bin2hex(s, &mut outbuf)
+                        .expect("should be able to convert unprintable string to hex");
+                    format!(
+                        "0x{}",
+                        std::str::from_utf8(&outbuf).expect("only hex digits expected")
+                    )
                 }
-            },
+            }
             SExp::Atom(l, a) => {
                 if a.is_empty() {
                     "()".to_string()

--- a/src/tests/compiler/compiler.rs
+++ b/src/tests/compiler/compiler.rs
@@ -28,9 +28,9 @@ fn run_string_maybe_opt(
     let runner = Rc::new(DefaultProgramRunner::new());
     let mut opts: Rc<dyn CompilerOpts> = Rc::new(DefaultCompilerOpts::new(&"*test*".to_string()));
     let srcloc = Srcloc::start(&"*test*".to_string());
-    opts = opts.
-        set_frontend_opt(fe_opt).
-        set_search_paths(&vec!["resources/tests".to_string()]);
+    opts = opts
+        .set_frontend_opt(fe_opt)
+        .set_search_paths(&vec!["resources/tests".to_string()]);
     let sexp_args = parse_sexp(srcloc.clone(), &args).map_err(|e| CompileErr(e.0, e.1))?[0].clone();
 
     compile_file(
@@ -549,8 +549,7 @@ fn test_defconstant() {
 
     assert_eq!(
         result.to_string(),
-        "((51 0x5f5767744f91c1c326d927a63d9b34fa7035c10e3eb838c44e3afe127c1b7675 2))"
-            .to_string()
+        "((51 0x5f5767744f91c1c326d927a63d9b34fa7035c10e3eb838c44e3afe127c1b7675 2))".to_string()
     );
 }
 
@@ -687,7 +686,7 @@ fn test_at_destructure_5() {
         .to_string(),
         &"(1 (2 3) 4)".to_string(),
     )
-        .unwrap();
+    .unwrap();
 
     assert_eq!(result.to_string(), "4".to_string());
 }
@@ -734,31 +733,38 @@ fn read_of_hex_constant_in_modern_chialisp() {
     )
         .unwrap();
 
-    assert_eq!(result.to_string(), "36364122602940516403027890844760998025315693007634105146514094828976803085567".to_string());
+    assert_eq!(
+        result.to_string(),
+        "36364122602940516403027890844760998025315693007634105146514094828976803085567".to_string()
+    );
 }
 
 #[test]
 fn hash_handling_test_2() {
     let result = run_string(
-        &indoc! {"(mod () (include *standard-cl-21*) (sha256 (q . 1) (q . 1)))"}
-        .to_string(),
-        &"()".to_string()
+        &indoc! {"(mod () (include *standard-cl-21*) (sha256 (q . 1) (q . 1)))"}.to_string(),
+        &"()".to_string(),
     )
-        .unwrap();
+    .unwrap();
 
-    assert_eq!(result.to_string(), "-44412188149083219915772186748035909266791016930429887947443501395007119841358");
+    assert_eq!(
+        result.to_string(),
+        "-44412188149083219915772186748035909266791016930429887947443501395007119841358"
+    );
 }
 
 #[test]
 fn hash_handling_test_3() {
     let result = run_string(
-        &indoc! {"(mod () (include *standard-cl-21*) (sha256 1 0))"}
-        .to_string(),
-        &"()".to_string()
+        &indoc! {"(mod () (include *standard-cl-21*) (sha256 1 0))"}.to_string(),
+        &"()".to_string(),
     )
-        .unwrap();
+    .unwrap();
 
-    assert_eq!(result.to_string(), "34356466678672179216206944866734405838331831190171667647615530531663699592602");
+    assert_eq!(
+        result.to_string(),
+        "34356466678672179216206944866734405838331831190171667647615530531663699592602"
+    );
 }
 
 #[test]

--- a/src/tests/compiler/compiler.rs
+++ b/src/tests/compiler/compiler.rs
@@ -248,7 +248,7 @@ fn run_test_7_maybe_opt(opt: bool) {
         ).unwrap();
     assert_eq!(
         result.to_string(),
-        "((51 305419896 1000000000))".to_string()
+        "((51 0x12345678 1000000000))".to_string()
     );
 }
 
@@ -547,7 +547,7 @@ fn test_defconstant() {
 
     assert_eq!(
         result.to_string(),
-        "((51 43124150325653191095732712509762329830013206679743532022320461771503765780085 2))"
+        "((51 0x5f5767744f91c1c326d927a63d9b34fa7035c10e3eb838c44e3afe127c1b7675 2))"
             .to_string()
     );
 }
@@ -685,7 +685,7 @@ fn test_at_destructure_5() {
         .to_string(),
         &"(1 (2 3) 4)".to_string(),
     )
-    .unwrap();
+        .unwrap();
 
     assert_eq!(result.to_string(), "4".to_string());
 }
@@ -715,13 +715,22 @@ fn test_collatz_maybe_opt(opt: bool) {
         opt,
     )
     .unwrap();
-    assert_eq!(result.to_string(), "(q . 2)");
+    assert_eq!(result.to_string(), "2");
 }
 
+#[test]
 fn test_collatz() {
     test_collatz_maybe_opt(false);
 }
 
-fn test_collatz_opt() {
-    test_collatz_maybe_opt(true);
+#[test]
+fn read_of_hex_constant_in_modern_chialisp() {
+    let result = run_string(
+        &indoc! {"(sha256 (q . 1) (q . 0xf22ada22a0ed015000ea157013ee62dc6ce337a649ec01054fc62ed6caac7eaf))"}
+        .to_string(),
+        &"()".to_string(),
+    )
+        .unwrap();
+
+    assert_eq!(result.to_string(), "36364122602940516403027890844760998025315693007634105146514094828976803085567".to_string());
 }

--- a/src/tests/compiler/compiler.rs
+++ b/src/tests/compiler/compiler.rs
@@ -28,7 +28,9 @@ fn run_string_maybe_opt(
     let runner = Rc::new(DefaultProgramRunner::new());
     let mut opts: Rc<dyn CompilerOpts> = Rc::new(DefaultCompilerOpts::new(&"*test*".to_string()));
     let srcloc = Srcloc::start(&"*test*".to_string());
-    opts = opts.set_frontend_opt(fe_opt);
+    opts = opts.
+        set_frontend_opt(fe_opt).
+        set_search_paths(&vec!["resources/tests".to_string()]);
     let sexp_args = parse_sexp(srcloc.clone(), &args).map_err(|e| CompileErr(e.0, e.1))?[0].clone();
 
     compile_file(
@@ -726,11 +728,118 @@ fn test_collatz() {
 #[test]
 fn read_of_hex_constant_in_modern_chialisp() {
     let result = run_string(
-        &indoc! {"(sha256 (q . 1) (q . 0xf22ada22a0ed015000ea157013ee62dc6ce337a649ec01054fc62ed6caac7eaf))"}
+        &indoc! {"(mod () (include *standard-cl-21*) (sha256 (q . 1) (q . 0xf22ada22a0ed015000ea157013ee62dc6ce337a649ec01054fc62ed6caac7eaf)))"}
         .to_string(),
         &"()".to_string(),
     )
         .unwrap();
 
     assert_eq!(result.to_string(), "36364122602940516403027890844760998025315693007634105146514094828976803085567".to_string());
+}
+
+#[test]
+fn hash_handling_test_2() {
+    let result = run_string(
+        &indoc! {"(mod () (include *standard-cl-21*) (sha256 (q . 1) (q . 1)))"}
+        .to_string(),
+        &"()".to_string()
+    )
+        .unwrap();
+
+    assert_eq!(result.to_string(), "-44412188149083219915772186748035909266791016930429887947443501395007119841358");
+}
+
+#[test]
+fn hash_handling_test_3() {
+    let result = run_string(
+        &indoc! {"(mod () (include *standard-cl-21*) (sha256 1 0))"}
+        .to_string(),
+        &"()".to_string()
+    )
+        .unwrap();
+
+    assert_eq!(result.to_string(), "34356466678672179216206944866734405838331831190171667647615530531663699592602");
+}
+
+#[test]
+fn sebastian_hash_test_1() {
+    let result = run_string(
+        &indoc! {"
+(mod (MOD_HASH TOKEN_A_AMOUNT TOKEN_B_AMOUNT K token_a_delta token_b_delta)
+    (include \"condition_codes.clvm\")
+    (include \"curry-and-treehash.clinc\")
+    (include *standard-cl-21*)
+
+    (defun sha256tree1 (TREE)
+        (if (l TREE)
+            (sha256 2 (sha256tree1 (f TREE)) (sha256tree1 (r TREE)))
+            (sha256 1 TREE)
+        )
+    )
+    (defun return-new-coin (mod_hash new_token_a_amount new_token_b_amount K)
+        (list (list mod_hash (sha256tree1 mod_hash))
+            (list
+                CREATE_COIN
+               (puzzle-hash-of-curried-function
+                    mod_hash (sha256tree1 mod_hash)
+                )
+                1
+            )
+        )
+    )
+
+    (let (
+         (new_token_a_amount (+ TOKEN_A_AMOUNT token_a_delta))
+         (new_token_b_amount (+ TOKEN_B_AMOUNT token_b_delta))
+        )
+        (if (all (= K (* new_token_a_amount new_token_b_amount)) (> new_token_a_amount 0) (> new_token_b_amount 0) )
+            (return-new-coin MOD_HASH new_token_a_amount new_token_b_amount K)
+            (x new_token_a_amount new_token_b_amount)
+        )
+    ))"}
+        .to_string(),
+        &"(0xf22ada22a0ed015000ea157013ee62dc6ce337a649ec01054fc62ed6caac7eaf 10000 200 2000000 -2000 50)".to_string()
+    )
+        .unwrap();
+
+    assert_eq!(result.to_string(), "((0xf22ada22a0ed015000ea157013ee62dc6ce337a649ec01054fc62ed6caac7eaf 36364122602940516403027890844760998025315693007634105146514094828976803085567) (51 -54330418644829767769717664495663952010367061369724157609947295940464695774007 1))");
+}
+
+#[test]
+fn sebastian_hash_test_2() {
+    let result = run_string(
+        &indoc! {"
+(mod (MOD_HASH TOKEN_A_AMOUNT TOKEN_B_AMOUNT K token_a_delta token_b_delta)
+    (include \"condition_codes.clvm\")
+    (include \"curry-and-treehash.clinc\")
+
+    (defun sha256tree1 (TREE)
+        (if (l TREE)
+            (sha256 2 (sha256tree1 (f TREE)) (sha256tree1 (r TREE)))
+            (sha256 1 TREE)
+        )
+    )
+    (defun return-new-coin (mod_hash new_token_a_amount new_token_b_amount K)
+        (list (list mod_hash (sha256tree1 mod_hash))
+            (list
+                CREATE_COIN
+               (puzzle-hash-of-curried-function
+                    mod_hash (sha256tree1 mod_hash)
+                )
+                1
+            )
+        )
+    )
+
+        (if (all (= K (* (+ TOKEN_A_AMOUNT token_a_delta) (+ TOKEN_B_AMOUNT token_b_delta))) (> (+ TOKEN_A_AMOUNT token_a_delta) 0) (> (+ TOKEN_B_AMOUNT token_b_delta) 0) )
+            (return-new-coin MOD_HASH (+ TOKEN_A_AMOUNT token_a_delta) (+ TOKEN_B_AMOUNT token_b_delta) K)
+            (x (+ TOKEN_A_AMOUNT token_a_delta) (+ TOKEN_B_AMOUNT token_b_delta))
+        )
+    )"}
+        .to_string(),
+        &"(0xf22ada22a0ed015000ea157013ee62dc6ce337a649ec01054fc62ed6caac7eaf 10000 200 2000000 -2000 50)".to_string()
+    )
+        .unwrap();
+
+    assert_eq!(result.to_string(), "((0xf22ada22a0ed015000ea157013ee62dc6ce337a649ec01054fc62ed6caac7eaf 36364122602940516403027890844760998025315693007634105146514094828976803085567) (51 -54330418644829767769717664495663952010367061369724157609947295940464695774007 1))");
 }

--- a/src/tests/compiler/repl.rs
+++ b/src/tests/compiler/repl.rs
@@ -103,7 +103,7 @@ fn test_last_of_pwcoin_1() {
             "  )",
             "(doit \"hello\" 0xdeadbeef 1)"
         ]).unwrap().unwrap(),
-        "(q (51 3735928559 1))"
+        "(q (51 0xdeadbeef 1))"
     );
 }
 
@@ -136,7 +136,7 @@ fn test_last_of_pwcoin_2() {
             "  (x)",
             "  )"
         ]).unwrap().unwrap(),
-        "(q (51 3735928559 1))"
+        "(q (51 0xdeadbeef 1))"
     );
 }
 


### PR DESCRIPTION
Several bug fixes:
- '#x' syntax in chialisp should look up the atom in the prims and insert the appropriate prim
- hex constants now modeled as QuotedString instead of Integer when parsed to preserve their structure
- QuotedString output can now degrade to hex constant
New real world tests for hash handling which exercise clvm boundary conversion to and from canonical int space