### PR TITLE
Add a 4th argument to compile_clvm to produce complex output 

### DIFF
--- a/.github/workflows/build-arm64-wheels.yml
+++ b/.github/workflows/build-arm64-wheels.yml
@@ -51,9 +51,9 @@ jobs:
             /opt/python/cp38-cp38/bin/python -m venv venv && \
             if [ ! -f "activate" ]; then ln -s venv/bin/activate; fi && \
             . ./activate && \
-            pip install maturin && \
+            pip install maturin==0.12.20 && \
             CC=gcc maturin build --release --strip --manylinux 2014 \
-                -E extension-module \
+             --no-sdist --cargo-extra-args=--all-features \
           '
 
     - name: Upload artifacts

--- a/.github/workflows/build-arm64-wheels.yml
+++ b/.github/workflows/build-arm64-wheels.yml
@@ -52,7 +52,7 @@ jobs:
             if [ ! -f "activate" ]; then ln -s venv/bin/activate; fi && \
             . ./activate && \
             pip install maturin && \
-            CC=gcc maturin build --no-sdist --release --strip --manylinux 2014 \
+            CC=gcc maturin build --release --strip --manylinux 2014 \
               --cargo-extra-args="--all-features" \
           '
 

--- a/.github/workflows/build-arm64-wheels.yml
+++ b/.github/workflows/build-arm64-wheels.yml
@@ -53,7 +53,7 @@ jobs:
             . ./activate && \
             pip install maturin && \
             CC=gcc maturin build --release --strip --manylinux 2014 \
-              --cargo-extra-args="--all-features" \
+                -E extension-module \
           '
 
     - name: Upload artifacts

--- a/.github/workflows/build-m1-wheel.yml
+++ b/.github/workflows/build-m1-wheel.yml
@@ -42,7 +42,7 @@ jobs:
         arch -arm64 python3 -m venv venv
         . ./venv/bin/activate
         export PATH=~/.cargo/bin:$PATH
-        arch -arm64 pip install maturin
+        arch -arm64 pip install maturin==0.12.20
         arch -arm64 maturin build --no-sdist -i python --release --strip --cargo-extra-args="--all-features"
         arch -arm64 cargo test --no-default-features
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -43,7 +43,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-          python -m pip install maturin
+          python -m pip install maturin==0.12.20
 
     - name: Build MacOs with maturin on Python ${{ matrix.python }}
       if: startsWith(matrix.os, 'macos')
@@ -78,7 +78,7 @@ jobs:
             if [ ! -f "activate" ]; then ln -s venv/bin/activate; fi && \
             . ./activate && \
             pip install --upgrade pip && \
-            pip install maturin && \
+            pip install maturin==0.12.20 && \
             CC=gcc maturin build --no-sdist --release --strip --manylinux 2010 \
           '
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "clvm_tools_rs"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "binascii",
  "bls12_381",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clvm_tools_rs"
-version = "0.1.19"
+version = "0.1.20"
 edition = "2018"
 authors = ["Art Yerkes <art.yerkes@gmail.com>"]
 description = "tools for working with chialisp language; compiler, repl, python and wasm bindings"

--- a/src/classic/clvm_tools/clvmc.rs
+++ b/src/classic/clvm_tools/clvmc.rs
@@ -131,11 +131,11 @@ pub fn compile_clvm(
     input_path: &String,
     output_path: &String,
     search_paths: &Vec<String>,
+    symbol_table: &mut HashMap<String, String>
 ) -> Result<String, String> {
     let mut allocator = Allocator::new();
 
     let compile = newer(input_path, output_path).unwrap_or_else(|_| true);
-    let mut symbol_table = HashMap::new();
     let mut result_stream = Stream::new(None);
 
     if compile {
@@ -145,7 +145,7 @@ pub fn compile_clvm(
         let _ = compile_clvm_inner(
             &mut allocator,
             search_paths,
-            &mut symbol_table,
+            symbol_table,
             input_path,
             &text,
             &mut result_stream,

--- a/src/classic/clvm_tools/clvmc.rs
+++ b/src/classic/clvm_tools/clvmc.rs
@@ -131,7 +131,7 @@ pub fn compile_clvm(
     input_path: &String,
     output_path: &String,
     search_paths: &Vec<String>,
-    symbol_table: &mut HashMap<String, String>
+    symbol_table: &mut HashMap<String, String>,
 ) -> Result<String, String> {
     let mut allocator = Allocator::new();
 

--- a/src/py/api.rs
+++ b/src/py/api.rs
@@ -33,12 +33,13 @@ fn get_version() -> PyResult<String> {
     Ok(env!("CARGO_PKG_VERSION").to_string())
 }
 
-#[pyfunction(arg3 = "[]")]
+#[pyfunction(arg3 = "[]", arg4 = "None")]
 fn compile_clvm(
     input_path: &PyAny,
     output_path: String,
     search_paths: Vec<String>,
-) -> PyResult<String> {
+    export_symbols: Option<bool>
+) -> PyResult<PyObject> {
     let has_atom = input_path.hasattr("atom")?;
     let has_pair = input_path.hasattr("pair")?;
 
@@ -59,8 +60,25 @@ fn compile_clvm(
         path_string = path_string + ".clvm";
     };
 
-    clvmc::compile_clvm(&path_string, &output_path, &search_paths)
-        .map_err(|s| PyException::new_err(s))
+    let mut symbols = HashMap::new();
+    let compiled = clvmc::compile_clvm(
+        &path_string,
+        &output_path,
+        &search_paths,
+        &mut symbols
+    )
+        .map_err(|s| PyException::new_err(s))?;
+
+    Python::with_gil(|py| {
+        if export_symbols == Some(true) {
+            let mut result_dict = HashMap::new();
+            result_dict.insert("output".to_string(), compiled.into_py(py));
+            result_dict.insert("symbols".to_string(), symbols.into_py(py));
+            Ok(result_dict.into_py(py))
+        } else {
+            Ok(compiled.into_py(py))
+        }
+    })
 }
 
 #[pyclass]

--- a/src/py/api.rs
+++ b/src/py/api.rs
@@ -38,7 +38,7 @@ fn compile_clvm(
     input_path: &PyAny,
     output_path: String,
     search_paths: Vec<String>,
-    export_symbols: Option<bool>
+    export_symbols: Option<bool>,
 ) -> PyResult<PyObject> {
     let has_atom = input_path.hasattr("atom")?;
     let has_pair = input_path.hasattr("pair")?;
@@ -61,12 +61,7 @@ fn compile_clvm(
     };
 
     let mut symbols = HashMap::new();
-    let compiled = clvmc::compile_clvm(
-        &path_string,
-        &output_path,
-        &search_paths,
-        &mut symbols
-    )
+    let compiled = clvmc::compile_clvm(&path_string, &output_path, &search_paths, &mut symbols)
         .map_err(|s| PyException::new_err(s))?;
 
     Python::with_gil(|py| {


### PR DESCRIPTION
{'output': as before, 'symbols': symbols} when true.
More keys can be added as we need them, but this should also retain compatibility
