### PR TITLE
Fix encoding of integers close to 4 bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,8 @@ dependencies = [
  "num-traits",
  "pyo3",
  "pyo3-build-config 0.15.2",
+ "rand",
+ "rand_chacha",
  "serde_json",
  "sha2",
  "tempfile",
@@ -477,6 +479,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
 name = "proc-macro-hack"
 version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -564,10 +572,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "redox_syscall"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,8 @@ clvmr = "0.1.21"
 binascii = "0.1.4"
 yaml-rust = "0.4"
 linked-hash-map = "0.5.6"
+
+[dev-dependencies]
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,8 @@ clvmr = "0.1.21"
 binascii = "0.1.4"
 yaml-rust = "0.4"
 linked-hash-map = "0.5.6"
+rand = "0.8.5"
+rand_chacha = "0.3.1"
 
 [lib]
 name = "clvm_tools_rs"

--- a/src/classic/clvm/casts.rs
+++ b/src/classic/clvm/casts.rs
@@ -125,6 +125,7 @@ pub fn bigint_to_bytes(v_: &Number, option: Option<TConvertOption>) -> Result<By
     let div = if signed { bi_one() } else { bi_zero() };
     let b32: u64 = 1_u64 << 32;
     let bval = b32.to_bigint().unwrap();
+    let (_sign, u32_digits) = v.to_u32_digits();
 
     if negative {
         let mut right_hand = (-(v.clone()) + bi_one()) * (div + bi_one());
@@ -136,14 +137,17 @@ pub fn bigint_to_bytes(v_: &Number, option: Option<TConvertOption>) -> Result<By
             byte_count += 1;
         }
     } else {
-        let mut right_hand = (v.clone() + bi_one()) * (div.clone() + bi_one());
-        while pow(bval.clone(), (byte_count - 1) / 4 + 1) < right_hand {
-            byte_count += 4;
-        }
-        right_hand = (v.clone() + bi_one()) * (div + bi_one());
-        while pow(2_u32.to_bigint().unwrap(), 8 * byte_count) < right_hand {
-            byte_count += 1;
-        }
+        let first_digit = u32_digits[u32_digits.len() - 1];
+        byte_count = (u32_digits.len() - 1) * 4 +
+            if first_digit >= 0x1000000 {
+                4
+            } else if first_digit >= 0x10000 {
+                3
+            } else if first_digit >= 0x100 {
+                2
+            } else {
+                1
+            };
     }
 
     let extra_byte = if signed
@@ -162,7 +166,6 @@ pub fn bigint_to_bytes(v_: &Number, option: Option<TConvertOption>) -> Result<By
 
     dv.resize(total_bytes, 0);
 
-    let (_sign, u32_digits) = v.to_u32_digits();
     for (i, n) in u32_digits.iter().take(byte4_length).enumerate() {
         let word_idx = byte4_length - i - 1;
         let num = *n as u64;

--- a/src/classic/clvm/casts.rs
+++ b/src/classic/clvm/casts.rs
@@ -109,14 +109,12 @@ pub fn bigint_from_bytes(b: &Bytes, option: Option<TConvertOption>) -> Number {
 
 // This is the version i ported from the typescript code re: chiaminejp.  It is
 // still used in some contexts, such as node_paths.
-pub fn bigint_to_bytes(v_: &Number, option: Option<TConvertOption>) -> Result<Bytes, String> {
-    let v = v_.clone();
-
-    if v == bi_zero() {
+pub fn bigint_to_bytes(v: &Number, option: Option<TConvertOption>) -> Result<Bytes, String> {
+    if *v == bi_zero() {
         return Ok(Bytes::new(None));
     }
 
-    let negative = v < bi_zero();
+    let negative = *v < bi_zero();
 
     let signed = option.map(|o| o.signed).unwrap_or_else(|| false);
     if !signed && negative {
@@ -153,8 +151,8 @@ pub fn bigint_to_bytes(v_: &Number, option: Option<TConvertOption>) -> Result<By
     }
 
     let extra_byte = if signed
-        && v > bi_zero()
-        && ((v >> ((byte_count - 1) * 8)) & 0x80_u32.to_bigint().unwrap()) > bi_zero()
+        && *v > bi_zero()
+        && ((v.clone() >> ((byte_count - 1) * 8)) & 0x80_u32.to_bigint().unwrap()) > bi_zero()
     {
         1
     } else {

--- a/src/classic/clvm/casts.rs
+++ b/src/classic/clvm/casts.rs
@@ -1,11 +1,10 @@
-use num::pow;
 use num_bigint::ToBigInt;
 
 use clvm_rs::allocator::Allocator;
 use clvm_rs::reduction::EvalErr;
 
 use crate::classic::clvm::__type_compatibility__::{
-    bi_one, bi_zero, get_u32, set_u32, set_u8, Bytes, BytesFromType,
+    bi_one, bi_zero, get_u32, Bytes, BytesFromType,
 };
 use crate::util::Number;
 
@@ -65,6 +64,7 @@ pub fn int_from_bytes(
     Ok(unsigned64)
 }
 
+// Newly pulled in from clvm_rs.
 pub fn bigint_from_bytes(b: &Bytes, option: Option<TConvertOption>) -> Number {
     if b.length() == 0 {
         return bi_zero();
@@ -107,92 +107,29 @@ pub fn bigint_from_bytes(b: &Bytes, option: Option<TConvertOption>) -> Number {
     unsigned
 }
 
-pub fn bigint_to_bytes(v_: &Number, option: Option<TConvertOption>) -> Result<Bytes, String> {
-    let v = v_.clone();
+// Pulled in code from clvm_rs to replace this function, re: PR comments.
+// The whole function relies on allocator so this is just the brass tacks.
+// Conversion type was here for completeness in the original code I ported
+// from the typescript.
+//
+// The unsigned option is easier, as used in as_path.
+pub fn bigint_to_bytes(v: &Number) -> Result<Bytes, String> {
+    let bytes: Vec<u8> = v.to_signed_bytes_be();
+    let mut slice = bytes.as_slice();
 
-    if v == bi_zero() {
-        return Ok(Bytes::new(None));
-    }
-
-    let negative = v < bi_zero();
-
-    let signed = option.map(|o| o.signed).unwrap_or_else(|| false);
-    if !signed && negative {
-        return Err("OverflowError: can't convert negative int to unsigned".to_string());
-    }
-    let mut byte_count = 1;
-    let mut dec = 0;
-    let div = if signed { bi_one() } else { bi_zero() };
-    let b32: u64 = 1_u64 << 32;
-    let bval = b32.to_bigint().unwrap();
-    let (_sign, u32_digits) = v.to_u32_digits();
-
-    if negative {
-        let mut right_hand = (-(v.clone()) + bi_one()) * (div + bi_one());
-        while pow(bval.clone(), (byte_count - 1) / 4 + 1) < right_hand {
-            byte_count += 4;
+    // make number minimal by removing leading zeros
+    while (!slice.is_empty()) && (slice[0] == 0) {
+        if slice.len() > 1 && (slice[1] & 0x80 == 0x80) {
+            break;
         }
-        right_hand = -(v.clone()) * 2.to_bigint().unwrap();
-        while pow(2.to_bigint().unwrap(), 8 * byte_count) < right_hand {
-            byte_count += 1;
-        }
-    } else {
-        let first_digit = u32_digits[u32_digits.len() - 1];
-        byte_count = (u32_digits.len() - 1) * 4
-            + if first_digit >= 0x1000000 {
-                4
-            } else if first_digit >= 0x10000 {
-                3
-            } else if first_digit >= 0x100 {
-                2
-            } else {
-                1
-            };
+        slice = &slice[1..];
     }
 
-    let extra_byte = if signed
-        && v > bi_zero()
-        && ((v >> ((byte_count - 1) * 8)) & 0x80_u32.to_bigint().unwrap()) > bi_zero()
-    {
-        1
-    } else {
-        0
-    };
+    Ok(Bytes::new(Some(BytesFromType::Raw(slice.to_vec()))))
+}
 
-    let total_bytes = byte_count + extra_byte;
-    let mut dv = Vec::<u8>::with_capacity(total_bytes);
-    let byte4_remain = byte_count % 4;
-    let byte4_length = (byte_count - byte4_remain) / 4;
-
-    dv.resize(total_bytes, 0);
-
-    for (i, n) in u32_digits.iter().take(byte4_length).enumerate() {
-        let word_idx = byte4_length - i - 1;
-        let num = *n as u64;
-        let pointer = extra_byte + byte4_remain + word_idx * 4;
-        let setval = if negative {
-            (1_u64 << 32) - num - dec as u64
-        } else {
-            num as u64
-        };
-        dec = 1;
-        set_u32(&mut dv, pointer, setval as u32);
-    }
-
-    let lastbytes = u32_digits[u32_digits.len() - 1];
-    let transform = |idx| {
-        if negative {
-            (((1 << (8 * byte4_remain)) - lastbytes - dec) >> (8 * idx)) as u8
-        } else {
-            (lastbytes >> (8 * idx)) as u8
-        }
-    };
-
-    for i in 0..byte4_remain {
-        set_u8(&mut dv, extra_byte + i, transform(byte4_remain - i - 1));
-    }
-
-    Ok(Bytes::new(Some(BytesFromType::Raw(dv))))
+pub fn bigint_to_bytes_unsigned(v: &Number) -> Result<Bytes, String> {
+    bigint_to_bytes(v)
 }
 
 // /**

--- a/src/classic/clvm/casts.rs
+++ b/src/classic/clvm/casts.rs
@@ -138,8 +138,8 @@ pub fn bigint_to_bytes(v_: &Number, option: Option<TConvertOption>) -> Result<By
         }
     } else {
         let first_digit = u32_digits[u32_digits.len() - 1];
-        byte_count = (u32_digits.len() - 1) * 4 +
-            if first_digit >= 0x1000000 {
+        byte_count = (u32_digits.len() - 1) * 4
+            + if first_digit >= 0x1000000 {
                 4
             } else if first_digit >= 0x10000 {
                 3

--- a/src/classic/clvm/casts.rs
+++ b/src/classic/clvm/casts.rs
@@ -152,7 +152,7 @@ pub fn bigint_to_bytes(v_: &Number, option: Option<TConvertOption>) -> Result<By
 
     let extra_byte = if signed
         && v > bi_zero()
-        && ((v.clone() >> ((byte_count - 1) * 8)) & 0x80_u32.to_bigint().unwrap()) > bi_zero()
+        && ((v >> ((byte_count - 1) * 8)) & 0x80_u32.to_bigint().unwrap()) > bi_zero()
     {
         1
     } else {

--- a/src/classic/clvm/casts.rs
+++ b/src/classic/clvm/casts.rs
@@ -108,16 +108,16 @@ pub fn bigint_from_bytes(b: &Bytes, option: Option<TConvertOption>) -> Number {
 
 // Convert to bytes with no leading zeros added.  This allows numbers to appear
 // negative in the result stream but are treated as positive (for node paths).
-pub fn bigint_to_bytes_unsigned(v: &Number) -> Result<Bytes, String> {
+pub fn bigint_to_bytes_unsigned(v: &Number) -> Bytes {
     if *v == bi_zero() {
-        return Ok(Bytes::new(None));
+        return Bytes::new(None);
     }
 
     // This is only for positive numbers.
     assert!(*v > bi_zero());
 
     let (_, result) = v.to_bytes_be();
-    Ok(Bytes::new(Some(BytesFromType::Raw(result))))
+    Bytes::new(Some(BytesFromType::Raw(result)))
 }
 
 // Pulled in code from clvm_rs to replace this function, re: PR comments.
@@ -126,7 +126,7 @@ pub fn bigint_to_bytes_unsigned(v: &Number) -> Result<Bytes, String> {
 // from the typescript.
 //
 // The unsigned option is easier, as used in as_path.
-pub fn bigint_to_bytes_clvm(v: &Number) -> Result<Bytes, String> {
+pub fn bigint_to_bytes_clvm(v: &Number) -> Bytes {
     let bytes: Vec<u8> = v.to_signed_bytes_be();
     let mut slice = bytes.as_slice();
 
@@ -138,7 +138,7 @@ pub fn bigint_to_bytes_clvm(v: &Number) -> Result<Bytes, String> {
         slice = &slice[1..];
     }
 
-    Ok(Bytes::new(Some(BytesFromType::Raw(slice.to_vec()))))
+    Bytes::new(Some(BytesFromType::Raw(slice.to_vec())))
 }
 
 // /**

--- a/src/classic/clvm/casts.rs
+++ b/src/classic/clvm/casts.rs
@@ -1,11 +1,10 @@
-use num::pow;
 use num_bigint::ToBigInt;
 
 use clvm_rs::allocator::Allocator;
 use clvm_rs::reduction::EvalErr;
 
 use crate::classic::clvm::__type_compatibility__::{
-    bi_one, bi_zero, get_u32, set_u32, set_u8, Bytes, BytesFromType,
+    bi_one, bi_zero, get_u32, Bytes, BytesFromType,
 };
 use crate::util::Number;
 
@@ -107,92 +106,39 @@ pub fn bigint_from_bytes(b: &Bytes, option: Option<TConvertOption>) -> Number {
     unsigned
 }
 
-// This is the version i ported from the typescript code re: chiaminejp.  It is
-// still used in some contexts, such as node_paths.
-pub fn bigint_to_bytes(v: &Number, option: Option<TConvertOption>) -> Result<Bytes, String> {
+// Convert to bytes with no leading zeros added.  This allows numbers to appear
+// negative in the result stream but are treated as positive (for node paths).
+pub fn bigint_to_bytes_unsigned(v: &Number) -> Result<Bytes, String> {
     if *v == bi_zero() {
         return Ok(Bytes::new(None));
     }
 
-    let negative = *v < bi_zero();
+    // This is only for positive numbers.
+    assert!(*v > bi_zero());
 
-    let signed = option.map(|o| o.signed).unwrap_or_else(|| false);
-    if !signed && negative {
-        return Err("OverflowError: can't convert negative int to unsigned".to_string());
-    }
-    let mut byte_count = 1;
-    let mut dec = 0;
-    let div = if signed { bi_one() } else { bi_zero() };
-    let b32: u64 = 1_u64 << 32;
-    let bval = b32.to_bigint().unwrap();
-    let (_sign, u32_digits) = v.to_u32_digits();
+    let (_, result) = v.to_bytes_be();
+    Ok(Bytes::new(Some(BytesFromType::Raw(result))))
+}
 
-    if negative {
-        let mut right_hand = (-(v.clone()) + bi_one()) * (div + bi_one());
-        while pow(bval.clone(), (byte_count - 1) / 4 + 1) < right_hand {
-            byte_count += 4;
+// Pulled in code from clvm_rs to replace this function, re: PR comments.
+// The whole function relies on allocator so this is just the brass tacks.
+// Conversion type was here for completeness in the original code I ported
+// from the typescript.
+//
+// The unsigned option is easier, as used in as_path.
+pub fn bigint_to_bytes_clvm(v: &Number) -> Result<Bytes, String> {
+    let bytes: Vec<u8> = v.to_signed_bytes_be();
+    let mut slice = bytes.as_slice();
+
+    // make number minimal by removing leading zeros
+    while (!slice.is_empty()) && (slice[0] == 0) {
+        if slice.len() > 1 && (slice[1] & 0x80 == 0x80) {
+            break;
         }
-        right_hand = -(v.clone()) * 2.to_bigint().unwrap();
-        while pow(2.to_bigint().unwrap(), 8 * byte_count) < right_hand {
-            byte_count += 1;
-        }
-    } else {
-        let first_digit = u32_digits[u32_digits.len() - 1];
-        byte_count = (u32_digits.len() - 1) * 4
-            + if first_digit >= 0x1000000 {
-                4
-            } else if first_digit >= 0x10000 {
-                3
-            } else if first_digit >= 0x100 {
-                2
-            } else {
-                1
-            };
+        slice = &slice[1..];
     }
 
-    let extra_byte = if signed
-        && *v > bi_zero()
-        && ((v.clone() >> ((byte_count - 1) * 8)) & 0x80_u32.to_bigint().unwrap()) > bi_zero()
-    {
-        1
-    } else {
-        0
-    };
-
-    let total_bytes = byte_count + extra_byte;
-    let mut dv = Vec::<u8>::with_capacity(total_bytes);
-    let byte4_remain = byte_count % 4;
-    let byte4_length = (byte_count - byte4_remain) / 4;
-
-    dv.resize(total_bytes, 0);
-
-    for (i, n) in u32_digits.iter().take(byte4_length).enumerate() {
-        let word_idx = byte4_length - i - 1;
-        let num = *n as u64;
-        let pointer = extra_byte + byte4_remain + word_idx * 4;
-        let setval = if negative {
-            (1_u64 << 32) - num - dec as u64
-        } else {
-            num as u64
-        };
-        dec = 1;
-        set_u32(&mut dv, pointer, setval as u32);
-    }
-
-    let lastbytes = u32_digits[u32_digits.len() - 1];
-    let transform = |idx| {
-        if negative {
-            (((1 << (8 * byte4_remain)) - lastbytes - dec) >> (8 * idx)) as u8
-        } else {
-            (lastbytes >> (8 * idx)) as u8
-        }
-    };
-
-    for i in 0..byte4_remain {
-        set_u8(&mut dv, extra_byte + i, transform(byte4_remain - i - 1));
-    }
-
-    Ok(Bytes::new(Some(BytesFromType::Raw(dv))))
+    Ok(Bytes::new(Some(BytesFromType::Raw(slice.to_vec()))))
 }
 
 // /**

--- a/src/classic/clvm/casts.rs
+++ b/src/classic/clvm/casts.rs
@@ -140,8 +140,8 @@ pub fn bigint_to_bytes(v_: &Number, option: Option<TConvertOption>) -> Result<By
         }
     } else {
         let first_digit = u32_digits[u32_digits.len() - 1];
-        byte_count = (u32_digits.len() - 1) * 4 +
-            if first_digit >= 0x1000000 {
+        byte_count = (u32_digits.len() - 1) * 4
+            + if first_digit >= 0x1000000 {
                 4
             } else if first_digit >= 0x10000 {
                 3
@@ -154,7 +154,7 @@ pub fn bigint_to_bytes(v_: &Number, option: Option<TConvertOption>) -> Result<By
 
     let extra_byte = if signed
         && v > bi_zero()
-        && ((v.clone() >> ((byte_count - 1) * 8)) & 0x80_u32.to_bigint().unwrap()) > bi_zero()
+        && ((v >> ((byte_count - 1) * 8)) & 0x80_u32.to_bigint().unwrap()) > bi_zero()
     {
         1
     } else {

--- a/src/classic/clvm/casts.rs
+++ b/src/classic/clvm/casts.rs
@@ -1,10 +1,11 @@
+use num::pow;
 use num_bigint::ToBigInt;
 
 use clvm_rs::allocator::Allocator;
 use clvm_rs::reduction::EvalErr;
 
 use crate::classic::clvm::__type_compatibility__::{
-    bi_one, bi_zero, get_u32, Bytes, BytesFromType,
+    bi_one, bi_zero, get_u32, set_u32, set_u8, Bytes, BytesFromType,
 };
 use crate::util::Number;
 
@@ -64,7 +65,6 @@ pub fn int_from_bytes(
     Ok(unsigned64)
 }
 
-// Newly pulled in from clvm_rs.
 pub fn bigint_from_bytes(b: &Bytes, option: Option<TConvertOption>) -> Number {
     if b.length() == 0 {
         return bi_zero();
@@ -107,29 +107,94 @@ pub fn bigint_from_bytes(b: &Bytes, option: Option<TConvertOption>) -> Number {
     unsigned
 }
 
-// Pulled in code from clvm_rs to replace this function, re: PR comments.
-// The whole function relies on allocator so this is just the brass tacks.
-// Conversion type was here for completeness in the original code I ported
-// from the typescript.
-//
-// The unsigned option is easier, as used in as_path.
-pub fn bigint_to_bytes(v: &Number) -> Result<Bytes, String> {
-    let bytes: Vec<u8> = v.to_signed_bytes_be();
-    let mut slice = bytes.as_slice();
+// This is the version i ported from the typescript code re: chiaminejp.  It is
+// still used in some contexts, such as node_paths.
+pub fn bigint_to_bytes(v_: &Number, option: Option<TConvertOption>) -> Result<Bytes, String> {
+    let v = v_.clone();
 
-    // make number minimal by removing leading zeros
-    while (!slice.is_empty()) && (slice[0] == 0) {
-        if slice.len() > 1 && (slice[1] & 0x80 == 0x80) {
-            break;
-        }
-        slice = &slice[1..];
+    if v == bi_zero() {
+        return Ok(Bytes::new(None));
     }
 
-    Ok(Bytes::new(Some(BytesFromType::Raw(slice.to_vec()))))
-}
+    let negative = v < bi_zero();
 
-pub fn bigint_to_bytes_unsigned(v: &Number) -> Result<Bytes, String> {
-    bigint_to_bytes(v)
+    let signed = option.map(|o| o.signed).unwrap_or_else(|| false);
+    if !signed && negative {
+        return Err("OverflowError: can't convert negative int to unsigned".to_string());
+    }
+    let mut byte_count = 1;
+    let mut dec = 0;
+    let div = if signed { bi_one() } else { bi_zero() };
+    let b32: u64 = 1_u64 << 32;
+    let bval = b32.to_bigint().unwrap();
+    let (_sign, u32_digits) = v.to_u32_digits();
+
+    if negative {
+        let mut right_hand = (-(v.clone()) + bi_one()) * (div + bi_one());
+        while pow(bval.clone(), (byte_count - 1) / 4 + 1) < right_hand {
+            byte_count += 4;
+        }
+        right_hand = -(v.clone()) * 2.to_bigint().unwrap();
+        while pow(2.to_bigint().unwrap(), 8 * byte_count) < right_hand {
+            byte_count += 1;
+        }
+    } else {
+        let first_digit = u32_digits[u32_digits.len() - 1];
+        byte_count = (u32_digits.len() - 1) * 4 +
+            if first_digit >= 0x1000000 {
+                4
+            } else if first_digit >= 0x10000 {
+                3
+            } else if first_digit >= 0x100 {
+                2
+            } else {
+                1
+            };
+    }
+
+    let extra_byte = if signed
+        && v > bi_zero()
+        && ((v.clone() >> ((byte_count - 1) * 8)) & 0x80_u32.to_bigint().unwrap()) > bi_zero()
+    {
+        1
+    } else {
+        0
+    };
+
+    let total_bytes = byte_count + extra_byte;
+    let mut dv = Vec::<u8>::with_capacity(total_bytes);
+    let byte4_remain = byte_count % 4;
+    let byte4_length = (byte_count - byte4_remain) / 4;
+
+    dv.resize(total_bytes, 0);
+
+    for (i, n) in u32_digits.iter().take(byte4_length).enumerate() {
+        let word_idx = byte4_length - i - 1;
+        let num = *n as u64;
+        let pointer = extra_byte + byte4_remain + word_idx * 4;
+        let setval = if negative {
+            (1_u64 << 32) - num - dec as u64
+        } else {
+            num as u64
+        };
+        dec = 1;
+        set_u32(&mut dv, pointer, setval as u32);
+    }
+
+    let lastbytes = u32_digits[u32_digits.len() - 1];
+    let transform = |idx| {
+        if negative {
+            (((1 << (8 * byte4_remain)) - lastbytes - dec) >> (8 * idx)) as u8
+        } else {
+            (lastbytes >> (8 * idx)) as u8
+        }
+    };
+
+    for i in 0..byte4_remain {
+        set_u8(&mut dv, extra_byte + i, transform(byte4_remain - i - 1));
+    }
+
+    Ok(Bytes::new(Some(BytesFromType::Raw(dv))))
 }
 
 // /**

--- a/src/classic/clvm_tools/ir/reader.rs
+++ b/src/classic/clvm_tools/ir/reader.rs
@@ -2,7 +2,7 @@ use std::mem::swap;
 use std::rc::Rc;
 
 use crate::classic::clvm::__type_compatibility__::{Bytes, BytesFromType, Stream};
-use crate::classic::clvm::casts::bigint_to_bytes;
+use crate::classic::clvm::casts::{bigint_to_bytes, TConvertOption};
 use crate::classic::clvm_tools::ir::r#type::IRRepr;
 use crate::util::Number;
 
@@ -146,7 +146,7 @@ pub fn interpret_atom_value(chars: &[u8]) -> IRRepr {
         match String::from_utf8(chars.to_vec())
             .ok()
             .and_then(|s| s.parse::<Number>().ok())
-            .and_then(|n| bigint_to_bytes(&n).ok())
+            .and_then(|n| bigint_to_bytes(&n, Some(TConvertOption { signed: true })).ok())
         {
             Some(n) => IRRepr::Int(n, true),
             None => {

--- a/src/classic/clvm_tools/ir/reader.rs
+++ b/src/classic/clvm_tools/ir/reader.rs
@@ -2,7 +2,7 @@ use std::mem::swap;
 use std::rc::Rc;
 
 use crate::classic::clvm::__type_compatibility__::{Bytes, BytesFromType, Stream};
-use crate::classic::clvm::casts::{bigint_to_bytes_clvm};
+use crate::classic::clvm::casts::bigint_to_bytes_clvm;
 use crate::classic::clvm_tools::ir::r#type::IRRepr;
 use crate::util::Number;
 

--- a/src/classic/clvm_tools/ir/reader.rs
+++ b/src/classic/clvm_tools/ir/reader.rs
@@ -146,7 +146,7 @@ pub fn interpret_atom_value(chars: &[u8]) -> IRRepr {
         match String::from_utf8(chars.to_vec())
             .ok()
             .and_then(|s| s.parse::<Number>().ok())
-            .and_then(|n| bigint_to_bytes_clvm(&n).ok())
+            .map(|n| bigint_to_bytes_clvm(&n))
         {
             Some(n) => IRRepr::Int(n, true),
             None => {

--- a/src/classic/clvm_tools/ir/reader.rs
+++ b/src/classic/clvm_tools/ir/reader.rs
@@ -2,7 +2,7 @@ use std::mem::swap;
 use std::rc::Rc;
 
 use crate::classic::clvm::__type_compatibility__::{Bytes, BytesFromType, Stream};
-use crate::classic::clvm::casts::{bigint_to_bytes, TConvertOption};
+use crate::classic::clvm::casts::bigint_to_bytes;
 use crate::classic::clvm_tools::ir::r#type::IRRepr;
 use crate::util::Number;
 
@@ -146,7 +146,7 @@ pub fn interpret_atom_value(chars: &[u8]) -> IRRepr {
         match String::from_utf8(chars.to_vec())
             .ok()
             .and_then(|s| s.parse::<Number>().ok())
-            .and_then(|n| bigint_to_bytes(&n, Some(TConvertOption { signed: true })).ok())
+            .and_then(|n| bigint_to_bytes(&n).ok())
         {
             Some(n) => IRRepr::Int(n, true),
             None => {

--- a/src/classic/clvm_tools/ir/reader.rs
+++ b/src/classic/clvm_tools/ir/reader.rs
@@ -2,7 +2,7 @@ use std::mem::swap;
 use std::rc::Rc;
 
 use crate::classic::clvm::__type_compatibility__::{Bytes, BytesFromType, Stream};
-use crate::classic::clvm::casts::{bigint_to_bytes, TConvertOption};
+use crate::classic::clvm::casts::{bigint_to_bytes_clvm};
 use crate::classic::clvm_tools::ir::r#type::IRRepr;
 use crate::util::Number;
 
@@ -146,7 +146,7 @@ pub fn interpret_atom_value(chars: &[u8]) -> IRRepr {
         match String::from_utf8(chars.to_vec())
             .ok()
             .and_then(|s| s.parse::<Number>().ok())
-            .and_then(|n| bigint_to_bytes(&n, Some(TConvertOption { signed: true })).ok())
+            .and_then(|n| bigint_to_bytes_clvm(&n).ok())
         {
             Some(n) => IRRepr::Int(n, true),
             None => {

--- a/src/classic/clvm_tools/node_path.rs
+++ b/src/classic/clvm_tools/node_path.rs
@@ -26,7 +26,7 @@
 use num_bigint::ToBigInt;
 
 use crate::classic::clvm::__type_compatibility__::{bi_one, bi_zero, Bytes};
-use crate::classic::clvm::casts::{bigint_from_bytes, bigint_to_bytes, TConvertOption};
+use crate::classic::clvm::casts::{bigint_from_bytes, bigint_to_bytes_clvm, bigint_to_bytes_unsigned};
 use crate::util::Number;
 
 pub fn compose_paths(path_0_: &Number, path_1_: &Number) -> Number {
@@ -70,7 +70,7 @@ impl NodePath {
             Some(index) => {
                 if index < bi_zero() {
                     let bytes_repr =
-                        bigint_to_bytes(&index, Some(TConvertOption { signed: true })).unwrap();
+                        bigint_to_bytes_clvm(&index).unwrap();
                     let unsigned = bigint_from_bytes(&bytes_repr, None);
                     NodePath { index: unsigned }
                 } else {
@@ -82,7 +82,7 @@ impl NodePath {
     }
 
     pub fn as_path(&self) -> Bytes {
-        bigint_to_bytes(&self.index, None).unwrap()
+        bigint_to_bytes_unsigned(&self.index).unwrap()
     }
 
     pub fn add(&self, other_node: NodePath) -> Self {

--- a/src/classic/clvm_tools/node_path.rs
+++ b/src/classic/clvm_tools/node_path.rs
@@ -26,7 +26,9 @@
 use num_bigint::ToBigInt;
 
 use crate::classic::clvm::__type_compatibility__::{bi_one, bi_zero, Bytes};
-use crate::classic::clvm::casts::{bigint_from_bytes, bigint_to_bytes_clvm, bigint_to_bytes_unsigned};
+use crate::classic::clvm::casts::{
+    bigint_from_bytes, bigint_to_bytes_clvm, bigint_to_bytes_unsigned,
+};
 use crate::util::Number;
 
 pub fn compose_paths(path_0_: &Number, path_1_: &Number) -> Number {
@@ -69,8 +71,7 @@ impl NodePath {
         match index {
             Some(index) => {
                 if index < bi_zero() {
-                    let bytes_repr =
-                        bigint_to_bytes_clvm(&index).unwrap();
+                    let bytes_repr = bigint_to_bytes_clvm(&index).unwrap();
                     let unsigned = bigint_from_bytes(&bytes_repr, None);
                     NodePath { index: unsigned }
                 } else {

--- a/src/classic/clvm_tools/node_path.rs
+++ b/src/classic/clvm_tools/node_path.rs
@@ -26,7 +26,7 @@
 use num_bigint::ToBigInt;
 
 use crate::classic::clvm::__type_compatibility__::{bi_one, bi_zero, Bytes};
-use crate::classic::clvm::casts::{bigint_from_bytes, bigint_to_bytes_unsigned};
+use crate::classic::clvm::casts::{bigint_from_bytes, bigint_to_bytes, TConvertOption};
 use crate::util::Number;
 
 pub fn compose_paths(path_0_: &Number, path_1_: &Number) -> Number {
@@ -69,7 +69,8 @@ impl NodePath {
         match index {
             Some(index) => {
                 if index < bi_zero() {
-                    let bytes_repr = bigint_to_bytes_unsigned(&index).unwrap();
+                    let bytes_repr =
+                        bigint_to_bytes(&index, Some(TConvertOption { signed: true })).unwrap();
                     let unsigned = bigint_from_bytes(&bytes_repr, None);
                     NodePath { index: unsigned }
                 } else {
@@ -81,7 +82,7 @@ impl NodePath {
     }
 
     pub fn as_path(&self) -> Bytes {
-        bigint_to_bytes_unsigned(&self.index).unwrap()
+        bigint_to_bytes(&self.index, None).unwrap()
     }
 
     pub fn add(&self, other_node: NodePath) -> Self {

--- a/src/classic/clvm_tools/node_path.rs
+++ b/src/classic/clvm_tools/node_path.rs
@@ -26,7 +26,7 @@
 use num_bigint::ToBigInt;
 
 use crate::classic::clvm::__type_compatibility__::{bi_one, bi_zero, Bytes};
-use crate::classic::clvm::casts::{bigint_from_bytes, bigint_to_bytes, TConvertOption};
+use crate::classic::clvm::casts::{bigint_from_bytes, bigint_to_bytes_unsigned};
 use crate::util::Number;
 
 pub fn compose_paths(path_0_: &Number, path_1_: &Number) -> Number {
@@ -69,8 +69,7 @@ impl NodePath {
         match index {
             Some(index) => {
                 if index < bi_zero() {
-                    let bytes_repr =
-                        bigint_to_bytes(&index, Some(TConvertOption { signed: true })).unwrap();
+                    let bytes_repr = bigint_to_bytes_unsigned(&index).unwrap();
                     let unsigned = bigint_from_bytes(&bytes_repr, None);
                     NodePath { index: unsigned }
                 } else {
@@ -82,7 +81,7 @@ impl NodePath {
     }
 
     pub fn as_path(&self) -> Bytes {
-        bigint_to_bytes(&self.index, None).unwrap()
+        bigint_to_bytes_unsigned(&self.index).unwrap()
     }
 
     pub fn add(&self, other_node: NodePath) -> Self {

--- a/src/classic/clvm_tools/node_path.rs
+++ b/src/classic/clvm_tools/node_path.rs
@@ -71,7 +71,7 @@ impl NodePath {
         match index {
             Some(index) => {
                 if index < bi_zero() {
-                    let bytes_repr = bigint_to_bytes_clvm(&index).unwrap();
+                    let bytes_repr = bigint_to_bytes_clvm(&index);
                     let unsigned = bigint_from_bytes(&bytes_repr, None);
                     NodePath { index: unsigned }
                 } else {
@@ -83,7 +83,7 @@ impl NodePath {
     }
 
     pub fn as_path(&self) -> Bytes {
-        bigint_to_bytes_unsigned(&self.index).unwrap()
+        bigint_to_bytes_unsigned(&self.index)
     }
 
     pub fn add(&self, other_node: NodePath) -> Self {

--- a/src/compiler/sexp.rs
+++ b/src/compiler/sexp.rs
@@ -1,6 +1,10 @@
+#[cfg(test)]
 use rand::distributions::Standard;
+#[cfg(test)]
 use rand::prelude::Distribution;
+#[cfg(test)]
 use rand::Rng;
+
 use std::borrow::Borrow;
 use std::fmt::Display;
 use std::hash::{Hash, Hasher};
@@ -28,6 +32,7 @@ pub enum SExp {
     Atom(Srcloc, Vec<u8>),
 }
 
+#[cfg(test)]
 pub fn random_atom_name<R: Rng + ?Sized>(rng: &mut R, min_size: usize) -> Vec<u8> {
     let mut bytevec: Vec<u8> = Vec::new();
     let mut len = 0;
@@ -44,10 +49,12 @@ pub fn random_atom_name<R: Rng + ?Sized>(rng: &mut R, min_size: usize) -> Vec<u8
     bytevec
 }
 
+#[cfg(test)]
 pub fn random_atom<R: Rng + ?Sized>(rng: &mut R) -> SExp {
     SExp::Atom(Srcloc::start("*rng*"), random_atom_name(rng, 1))
 }
 
+#[cfg(test)]
 pub fn random_sexp<R: Rng + ?Sized>(rng: &mut R, remaining: usize) -> SExp {
     if remaining < 2 {
         random_atom(rng)
@@ -86,6 +93,7 @@ pub fn random_sexp<R: Rng + ?Sized>(rng: &mut R, remaining: usize) -> SExp {
 }
 
 // Thanks: https://stackoverflow.com/questions/48490049/how-do-i-choose-a-random-value-from-an-enum
+#[cfg(test)]
 impl Distribution<SExp> for Standard {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> SExp {
         random_sexp(rng, MAX_SEXP_COST)
@@ -407,10 +415,7 @@ impl SExp {
                 b.encode_mut(v);
             }
             SExp::Integer(_, i) => {
-                let mut bi_bytes = bigint_to_bytes(i, Some(TConvertOption { signed: true }))
-                    .unwrap()
-                    .data()
-                    .to_vec();
+                let mut bi_bytes = bigint_to_bytes(i).unwrap().data().to_vec();
 
                 v.append(&mut bi_bytes);
             }

--- a/src/compiler/sexp.rs
+++ b/src/compiler/sexp.rs
@@ -45,10 +45,7 @@ pub fn random_atom_name<R: Rng + ?Sized>(rng: &mut R, min_size: usize) -> Vec<u8
 }
 
 pub fn random_atom<R: Rng + ?Sized>(rng: &mut R) -> SExp {
-    SExp::Atom(
-        Srcloc::start("*rng*"),
-        random_atom_name(rng, 1),
-    )
+    SExp::Atom(Srcloc::start("*rng*"), random_atom_name(rng, 1))
 }
 
 pub fn random_sexp<R: Rng + ?Sized>(rng: &mut R, remaining: usize) -> SExp {

--- a/src/compiler/sexp.rs
+++ b/src/compiler/sexp.rs
@@ -415,7 +415,10 @@ impl SExp {
                 b.encode_mut(v);
             }
             SExp::Integer(_, i) => {
-                let mut bi_bytes = bigint_to_bytes(i).unwrap().data().to_vec();
+                let mut bi_bytes = bigint_to_bytes(i, Some(TConvertOption { signed: true }))
+                    .unwrap()
+                    .data()
+                    .to_vec();
 
                 v.append(&mut bi_bytes);
             }

--- a/src/compiler/sexp.rs
+++ b/src/compiler/sexp.rs
@@ -45,7 +45,10 @@ pub fn random_atom_name<R: Rng + ?Sized>(rng: &mut R, min_size: usize) -> Vec<u8
 }
 
 pub fn random_atom<R: Rng + ?Sized>(rng: &mut R) -> SExp {
-    SExp::Atom(Srcloc::start(&"*rng*".to_string()), random_atom_name(rng, 1))
+    SExp::Atom(
+        Srcloc::start("*rng*"),
+        random_atom_name(rng, 1),
+    )
 }
 
 pub fn random_sexp<R: Rng + ?Sized>(rng: &mut R, remaining: usize) -> SExp {
@@ -55,17 +58,30 @@ pub fn random_sexp<R: Rng + ?Sized>(rng: &mut R, remaining: usize) -> SExp {
         let loc = || Srcloc::start("*rng*");
         let alternative: usize = rng.gen_range(0..=2);
         match alternative {
-            0 => { // list
+            0 => {
+                // list
                 let length = rng.gen_range(1..=remaining);
                 let costs = vec![remaining / length; length];
-                enlist(loc(), costs.iter().map(|c| Rc::new(random_sexp(rng, *c))).collect())
-            },
-            1 => { // cons
+                enlist(
+                    loc(),
+                    costs
+                        .iter()
+                        .map(|c| Rc::new(random_sexp(rng, *c)))
+                        .collect(),
+                )
+            }
+            1 => {
+                // cons
                 let left_cost = rng.gen_range(1..=remaining);
                 let right_cost = remaining - left_cost;
-                SExp::Cons(loc(), Rc::new(random_sexp(rng, left_cost)), Rc::new(random_sexp(rng, right_cost)))
-            },
-            _ => { // atom
+                SExp::Cons(
+                    loc(),
+                    Rc::new(random_sexp(rng, left_cost)),
+                    Rc::new(random_sexp(rng, right_cost)),
+                )
+            }
+            _ => {
+                // atom
                 random_atom(rng)
             }
         }

--- a/src/compiler/sexp.rs
+++ b/src/compiler/sexp.rs
@@ -415,10 +415,7 @@ impl SExp {
                 b.encode_mut(v);
             }
             SExp::Integer(_, i) => {
-                let mut bi_bytes = bigint_to_bytes_clvm(i)
-                    .unwrap()
-                    .data()
-                    .to_vec();
+                let mut bi_bytes = bigint_to_bytes_clvm(i).unwrap().data().to_vec();
 
                 v.append(&mut bi_bytes);
             }

--- a/src/compiler/sexp.rs
+++ b/src/compiler/sexp.rs
@@ -15,7 +15,7 @@ use binascii::{bin2hex, hex2bin};
 use num_traits::{zero, Num};
 
 use crate::classic::clvm::__type_compatibility__::{bi_zero, Bytes, BytesFromType};
-use crate::classic::clvm::casts::{bigint_from_bytes, bigint_to_bytes, TConvertOption};
+use crate::classic::clvm::casts::{bigint_from_bytes, bigint_to_bytes_clvm, TConvertOption};
 use crate::compiler::prims::prims;
 use crate::compiler::srcloc::Srcloc;
 use crate::util::{number_from_u8, u8_from_number, Number};
@@ -415,7 +415,7 @@ impl SExp {
                 b.encode_mut(v);
             }
             SExp::Integer(_, i) => {
-                let mut bi_bytes = bigint_to_bytes(i, Some(TConvertOption { signed: true }))
+                let mut bi_bytes = bigint_to_bytes_clvm(i)
                     .unwrap()
                     .data()
                     .to_vec();

--- a/src/compiler/sexp.rs
+++ b/src/compiler/sexp.rs
@@ -415,7 +415,7 @@ impl SExp {
                 b.encode_mut(v);
             }
             SExp::Integer(_, i) => {
-                let mut bi_bytes = bigint_to_bytes_clvm(i).unwrap().data().to_vec();
+                let mut bi_bytes = bigint_to_bytes_clvm(i).data().to_vec();
 
                 v.append(&mut bi_bytes);
             }

--- a/src/tests/classic/mod.rs
+++ b/src/tests/classic/mod.rs
@@ -1,4 +1,4 @@
 mod optimize;
-mod run;
+pub mod run;
 mod smoke;
 mod stage_2;

--- a/src/tests/classic/run.rs
+++ b/src/tests/classic/run.rs
@@ -443,9 +443,9 @@ fn test_check_tricky_arg_path_random() {
                     Rc::new(sexp::SExp::Cons(
                         random_tree.loc(),
                         Rc::new(sexp::SExp::Atom(random_tree.loc(), vec![b'q'])),
-                        deep_tree.clone()
+                        deep_tree.clone(),
                     )),
-                    Rc::new(sexp::SExp::Nil(random_tree.loc()))
+                    Rc::new(sexp::SExp::Nil(random_tree.loc())),
                 )),
             )),
         );

--- a/src/tests/classic/run.rs
+++ b/src/tests/classic/run.rs
@@ -259,12 +259,19 @@ fn test_forms_of_destructuring_allowed_by_classic_1() {
 
 #[test]
 fn test_num_encoding_just_less_than_5_bytes() {
-    let res = do_basic_run(&vec!["run".to_string(), "4281419728".to_string()]).trim().to_string();
+    let res = do_basic_run(&vec!["run".to_string(), "4281419728".to_string()])
+        .trim()
+        .to_string();
     assert_eq!(res, "0x00ff3147d0");
 }
 
 #[test]
 fn test_divmod() {
-    let res = do_basic_run(&vec!["run".to_string(), "(/ 78962960182680 4281419728)".to_string()]).trim().to_string();
+    let res = do_basic_run(&vec![
+        "run".to_string(),
+        "(/ 78962960182680 4281419728)".to_string(),
+    ])
+    .trim()
+    .to_string();
     assert_eq!(res, "18443");
 }

--- a/src/tests/classic/run.rs
+++ b/src/tests/classic/run.rs
@@ -440,8 +440,12 @@ fn test_check_tricky_arg_path_random() {
                 )),
                 Rc::new(sexp::SExp::Cons(
                     random_tree.loc(),
-                    Rc::new(sexp::SExp::Atom(random_tree.loc(), vec![b'@'])),
-                    Rc::new(sexp::SExp::Nil(random_tree.loc())),
+                    Rc::new(sexp::SExp::Cons(
+                        random_tree.loc(),
+                        Rc::new(sexp::SExp::Atom(random_tree.loc(), vec![b'q'])),
+                        deep_tree.clone()
+                    )),
+                    Rc::new(sexp::SExp::Nil(random_tree.loc()))
                 )),
             )),
         );
@@ -449,7 +453,7 @@ fn test_check_tricky_arg_path_random() {
         let res = do_basic_run(&vec![
             "run".to_string(),
             program.to_string(),
-            deep_tree.to_string(),
+            "()".to_string(),
         ])
         .trim()
         .to_string();

--- a/src/tests/classic/run.rs
+++ b/src/tests/classic/run.rs
@@ -300,12 +300,12 @@ fn test_divmod() {
 }
 
 #[cfg(test)]
-struct RandomClvmNumber {
-    intended_value: Number,
+pub struct RandomClvmNumber {
+    pub intended_value: Number,
 }
 
 #[cfg(test)]
-fn random_clvm_number<R: Rng + ?Sized>(rng: &mut R) -> RandomClvmNumber {
+pub fn random_clvm_number<R: Rng + ?Sized>(rng: &mut R) -> RandomClvmNumber {
     // Make a number by creating some random atom bytes.
     // Set high bit randomly.
     let natoms = rng.gen_range(0..=NUM_GEN_ATOMS);

--- a/src/tests/classic/run.rs
+++ b/src/tests/classic/run.rs
@@ -294,8 +294,8 @@ fn test_divmod() {
         "run".to_string(),
         "(/ 78962960182680 4281419728)".to_string(),
     ])
-        .trim()
-        .to_string();
+    .trim()
+    .to_string();
     assert_eq!(res, "18443");
 }
 

--- a/src/tests/classic/run.rs
+++ b/src/tests/classic/run.rs
@@ -256,3 +256,15 @@ fn test_forms_of_destructuring_allowed_by_classic_1() {
         "(i 2 (q . 2) (q . 3))"
     );
 }
+
+#[test]
+fn test_num_encoding_just_less_than_5_bytes() {
+    let res = do_basic_run(&vec!["run".to_string(), "4281419728".to_string()]).trim().to_string();
+    assert_eq!(res, "0x00ff3147d0");
+}
+
+#[test]
+fn test_divmod() {
+    let res = do_basic_run(&vec!["run".to_string(), "(/ 78962960182680 4281419728)".to_string()]).trim().to_string();
+    assert_eq!(res, "18443");
+}

--- a/src/tests/classic/run.rs
+++ b/src/tests/classic/run.rs
@@ -1,12 +1,27 @@
-use rand::distributions::Standard;
-use rand::prelude::*;
-use rand::Rng;
-use rand_chacha::ChaChaRng;
-use std::path::PathBuf;
+use num_bigint::ToBigInt;
 
-use crate::classic::clvm::__type_compatibility__::Stream;
+#[cfg(test)]
+use rand::distributions::Standard;
+#[cfg(test)]
+use rand::prelude::*;
+#[cfg(test)]
+use rand::Rng;
+#[cfg(test)]
+use rand_chacha::ChaChaRng;
+
+use std::borrow::Borrow;
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::rc::Rc;
+
+use clvmr::allocator::Allocator;
+
+use crate::classic::clvm::__type_compatibility__::{bi_one, bi_zero, Stream};
+use crate::classic::clvm_tools::binutils::disassemble;
 use crate::classic::clvm_tools::cmds::launch_tool;
-use crate::compiler::sexp::random_atom_name;
+use crate::classic::clvm_tools::node_path::NodePath;
+use crate::compiler::clvm::convert_to_clvm_rs;
+use crate::compiler::sexp;
 use crate::util::{number_from_u8, Number};
 
 const NUM_GEN_ATOMS: usize = 16;
@@ -284,17 +299,19 @@ fn test_divmod() {
     assert_eq!(res, "18443");
 }
 
+#[cfg(test)]
 struct RandomClvmNumber {
     intended_value: Number,
 }
 
+#[cfg(test)]
 fn random_clvm_number<R: Rng + ?Sized>(rng: &mut R) -> RandomClvmNumber {
     // Make a number by creating some random atom bytes.
     // Set high bit randomly.
     let natoms = rng.gen_range(0..=NUM_GEN_ATOMS);
     let mut result_bytes = Vec::new();
     for _ in 0..=natoms {
-        let mut new_bytes = random_atom_name(rng, 3)
+        let mut new_bytes = sexp::random_atom_name(rng, 3)
             .iter()
             .map(|x| {
                 if rng.gen() {
@@ -314,6 +331,7 @@ fn random_clvm_number<R: Rng + ?Sized>(rng: &mut R) -> RandomClvmNumber {
     }
 }
 
+#[cfg(test)]
 impl Distribution<RandomClvmNumber> for Standard {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> RandomClvmNumber {
         random_clvm_number(rng)
@@ -349,5 +367,98 @@ fn test_encoding_properties() {
         .trim()
         .to_string();
         assert_eq!(cancelled_through_run, "()");
+    }
+}
+
+const SEXP_RNG_HORIZON: usize = 13;
+const SEXP_DEPTH: usize = 2;
+
+#[cfg(test)]
+fn gather_paths(
+    path_map: &mut HashMap<Vec<u8>, Number>,
+    p: Number,
+    mask: Number,
+    sexp: &sexp::SExp,
+) {
+    let this_path = p.clone() | mask.clone();
+    match sexp {
+        sexp::SExp::Atom(_, x) => {
+            path_map.insert(x.clone(), this_path);
+        }
+        sexp::SExp::Cons(_, a, b) => {
+            let next_mask = mask * 2_u32.to_bigint().unwrap();
+            gather_paths(path_map, p.clone(), next_mask.clone(), a.borrow());
+            gather_paths(path_map, this_path, next_mask.clone(), b.borrow());
+        }
+        _ => {}
+    }
+}
+
+#[test]
+fn test_check_tricky_arg_path_random() {
+    let mut rng = ChaChaRng::from_entropy();
+    // Make a very deep random sexp and make a path table in it.
+    let random_tree = Rc::new(sexp::random_sexp(&mut rng, SEXP_RNG_HORIZON));
+    let mut deep_tree = random_tree.clone();
+
+    let mut path_map = HashMap::new();
+    gather_paths(&mut path_map, bi_zero(), bi_one(), &random_tree);
+    let mut deep_path = bi_one();
+    for _ in 1..=SEXP_DEPTH {
+        deep_path *= 2_u32.to_bigint().unwrap();
+        if rng.gen() {
+            deep_path |= bi_one();
+            deep_tree = Rc::new(sexp::SExp::Cons(
+                random_tree.loc(),
+                Rc::new(sexp::SExp::Nil(random_tree.loc())),
+                deep_tree,
+            ));
+        } else {
+            deep_tree = Rc::new(sexp::SExp::Cons(
+                random_tree.loc(),
+                deep_tree.clone(),
+                Rc::new(sexp::SExp::Nil(random_tree.loc())),
+            ));
+        }
+    }
+    // Now we have a very deep tree and a path to our sexp.
+    // We'll test whether node path serializes to the right thing by
+    // checking that we can reach all the atoms in our tree.
+    for (k, v) in path_map {
+        let np = NodePath::new(Some(deep_path.clone()));
+        let up = NodePath::new(Some(v.clone()));
+        let path_bytes = np.add(up).as_path();
+        let program = sexp::SExp::Cons(
+            random_tree.loc(),
+            Rc::new(sexp::SExp::Atom(random_tree.loc(), vec![b'a'])),
+            Rc::new(sexp::SExp::Cons(
+                random_tree.loc(),
+                Rc::new(sexp::SExp::Atom(
+                    random_tree.loc(),
+                    path_bytes.raw().clone(),
+                )),
+                Rc::new(sexp::SExp::Cons(
+                    random_tree.loc(),
+                    Rc::new(sexp::SExp::Atom(random_tree.loc(), vec![b'@'])),
+                    Rc::new(sexp::SExp::Nil(random_tree.loc())),
+                )),
+            )),
+        );
+
+        let res = do_basic_run(&vec![
+            "run".to_string(),
+            program.to_string(),
+            deep_tree.to_string(),
+        ])
+        .trim()
+        .to_string();
+        let mut allocator = Allocator::new();
+        let converted = convert_to_clvm_rs(
+            &mut allocator,
+            Rc::new(sexp::SExp::Atom(random_tree.loc(), k.clone())),
+        )
+        .unwrap();
+        let disassembled = disassemble(&mut allocator, converted);
+        assert_eq!(disassembled, res);
     }
 }

--- a/src/tests/classic/run.rs
+++ b/src/tests/classic/run.rs
@@ -1,13 +1,13 @@
-use std::path::PathBuf;
-use rand::prelude::*;
 use rand::distributions::Standard;
+use rand::prelude::*;
 use rand::Rng;
 use rand_chacha::ChaChaRng;
+use std::path::PathBuf;
 
 use crate::classic::clvm::__type_compatibility__::Stream;
 use crate::classic::clvm_tools::cmds::launch_tool;
-use crate::compiler::sexp::{random_atom_name};
-use crate::util::{Number, number_from_u8};
+use crate::compiler::sexp::random_atom_name;
+use crate::util::{number_from_u8, Number};
 
 const NUM_GEN_ATOMS: usize = 16;
 
@@ -279,13 +279,13 @@ fn test_divmod() {
         "run".to_string(),
         "(/ 78962960182680 4281419728)".to_string(),
     ])
-        .trim()
-        .to_string();
+    .trim()
+    .to_string();
     assert_eq!(res, "18443");
 }
 
 struct RandomClvmNumber {
-    intended_value: Number
+    intended_value: Number,
 }
 
 fn random_clvm_number<R: Rng + ?Sized>(rng: &mut R) -> RandomClvmNumber {
@@ -294,20 +294,23 @@ fn random_clvm_number<R: Rng + ?Sized>(rng: &mut R) -> RandomClvmNumber {
     let natoms = rng.gen_range(0..=NUM_GEN_ATOMS);
     let mut result_bytes = Vec::new();
     for _ in 0..=natoms {
-        let mut new_bytes = random_atom_name(rng, 3).iter().map(|x| {
-            if rng.gen() {
-                // The possibility of negative values.
-                x | 0x80
-            } else {
-                *x
-            }
-        }).collect();
+        let mut new_bytes = random_atom_name(rng, 3)
+            .iter()
+            .map(|x| {
+                if rng.gen() {
+                    // The possibility of negative values.
+                    x | 0x80
+                } else {
+                    *x
+                }
+            })
+            .collect();
         result_bytes.append(&mut new_bytes);
     }
     let num = number_from_u8(&result_bytes);
 
     RandomClvmNumber {
-        intended_value: num
+        intended_value: num,
     }
 }
 
@@ -327,23 +330,24 @@ fn test_encoding_properties() {
         // We'll have it compile a constant value.
         // The representation of the number will come out most likely
         // as a hex constant.
-        let serialized_through_run =
-            do_basic_run(&vec![
-                "run".to_string(),
-                format!("(q . {})", number_spec.intended_value)
-            ])
-            .trim()
-            .to_string();
+        let serialized_through_run = do_basic_run(&vec![
+            "run".to_string(),
+            format!("(q . {})", number_spec.intended_value),
+        ])
+        .trim()
+        .to_string();
 
         // If we can subtract the original value from the encoded value and
         // get zero, then we did the right thing.
-        let cancelled_through_run =
-            do_basic_run(&vec![
-                "run".to_string(),
-                format!("(- {} {})", serialized_through_run, number_spec.intended_value)
-            ])
-            .trim()
-            .to_string();
+        let cancelled_through_run = do_basic_run(&vec![
+            "run".to_string(),
+            format!(
+                "(- {} {})",
+                serialized_through_run, number_spec.intended_value
+            ),
+        ])
+        .trim()
+        .to_string();
         assert_eq!(cancelled_through_run, "()");
     }
 }

--- a/src/tests/classic/run.rs
+++ b/src/tests/classic/run.rs
@@ -294,8 +294,8 @@ fn test_divmod() {
         "run".to_string(),
         "(/ 78962960182680 4281419728)".to_string(),
     ])
-    .trim()
-    .to_string();
+        .trim()
+        .to_string();
     assert_eq!(res, "18443");
 }
 

--- a/src/tests/classic/run.rs
+++ b/src/tests/classic/run.rs
@@ -398,21 +398,13 @@ fn gather_paths(
 #[cfg(test)]
 fn stringize(sexp: &sexp::SExp) -> sexp::SExp {
     match sexp {
-        sexp::SExp::Cons(l,a,b) => {
-            sexp::SExp::Cons(
-                l.clone(),
-                Rc::new(stringize(a.borrow())),
-                Rc::new(stringize(b.borrow()))
-            )
-        },
-        sexp::SExp::Atom(l,n) => {
-            sexp::SExp::QuotedString(
-                l.clone(),
-                b'"',
-                n.clone()
-            )
-        },
-        _ => sexp.clone()
+        sexp::SExp::Cons(l, a, b) => sexp::SExp::Cons(
+            l.clone(),
+            Rc::new(stringize(a.borrow())),
+            Rc::new(stringize(b.borrow())),
+        ),
+        sexp::SExp::Atom(l, n) => sexp::SExp::QuotedString(l.clone(), b'"', n.clone()),
+        _ => sexp.clone(),
     }
 }
 

--- a/src/tests/classic/run.rs
+++ b/src/tests/classic/run.rs
@@ -433,8 +433,9 @@ fn test_check_tricky_arg_path_random() {
             Rc::new(sexp::SExp::Atom(random_tree.loc(), vec![b'a'])),
             Rc::new(sexp::SExp::Cons(
                 random_tree.loc(),
-                Rc::new(sexp::SExp::Atom(
+                Rc::new(sexp::SExp::QuotedString(
                     random_tree.loc(),
+                    b'"',
                     path_bytes.raw().clone(),
                 )),
                 Rc::new(sexp::SExp::Cons(

--- a/src/tests/classic/smoke.rs
+++ b/src/tests/classic/smoke.rs
@@ -1,3 +1,5 @@
+use num_bigint::ToBigInt;
+
 use std::fs;
 use std::path::PathBuf;
 use std::rc::Rc;
@@ -536,4 +538,22 @@ fn test_non_consed_args() {
     );
     let run_result = t.get_value().decode().trim().to_string();
     assert_eq!(run_result, "99");
+}
+
+#[test]
+fn test_check_simple_arg_path_0() {
+    let np = NodePath::new(Some(2_u32.to_bigint().unwrap()));
+    let up = NodePath::new(Some(2_u32.to_bigint().unwrap()));
+    let cp = np.add(up);
+    assert_eq!(cp.as_path().raw(), &[4]);
+}
+
+#[test]
+fn test_check_tricky_arg_path_1() {
+    let np = NodePath::new(Some(4294967295_u32.to_bigint().unwrap()));
+    let path_bytes = np.as_path();
+    assert_eq!(path_bytes.raw(), &[0, 255, 255, 255, 255]);
+    let next_path_segment = NodePath::new(Some(511_u32.to_bigint().unwrap()));
+    let next_path = np.add(next_path_segment);
+    assert_eq!(next_path.as_path().raw(), &[0, 255, 255, 255, 255, 255]);
 }

--- a/src/tests/classic/smoke.rs
+++ b/src/tests/classic/smoke.rs
@@ -48,7 +48,7 @@ fn large_odd_sized_neg_opd() {
 fn large_odd_sized_pos_opc() {
     let mut allocator = Allocator::new();
     let result = OpcConversion {}
-    .invoke(&mut allocator, &"(281474976710655)".to_string())
+        .invoke(&mut allocator, &"(281474976710655)".to_string())
         .unwrap();
     assert_eq!(result.rest(), "ff8700ffffffffffff80");
 }
@@ -57,7 +57,7 @@ fn large_odd_sized_pos_opc() {
 fn small_test_opc() {
     let mut allocator = Allocator::new();
     let result = OpcConversion {}
-    .invoke(&mut allocator, &"(191)".to_string())
+        .invoke(&mut allocator, &"(191)".to_string())
         .unwrap();
     assert_eq!(result.rest(), "ff8200bf80");
 }

--- a/src/tests/classic/smoke.rs
+++ b/src/tests/classic/smoke.rs
@@ -48,9 +48,18 @@ fn large_odd_sized_neg_opd() {
 fn large_odd_sized_pos_opc() {
     let mut allocator = Allocator::new();
     let result = OpcConversion {}
-        .invoke(&mut allocator, &"(281474976710655)".to_string())
+    .invoke(&mut allocator, &"(281474976710655)".to_string())
         .unwrap();
     assert_eq!(result.rest(), "ff8700ffffffffffff80");
+}
+
+#[test]
+fn small_test_opc() {
+    let mut allocator = Allocator::new();
+    let result = OpcConversion {}
+    .invoke(&mut allocator, &"(191)".to_string())
+        .unwrap();
+    assert_eq!(result.rest(), "ff8200bf80");
 }
 
 #[test]
@@ -546,14 +555,4 @@ fn test_check_simple_arg_path_0() {
     let up = NodePath::new(Some(2_u32.to_bigint().unwrap()));
     let cp = np.add(up);
     assert_eq!(cp.as_path().raw(), &[4]);
-}
-
-#[test]
-fn test_check_tricky_arg_path_1() {
-    let np = NodePath::new(Some(4294967295_u32.to_bigint().unwrap()));
-    let path_bytes = np.as_path();
-    assert_eq!(path_bytes.raw(), &[0, 255, 255, 255, 255]);
-    let next_path_segment = NodePath::new(Some(511_u32.to_bigint().unwrap()));
-    let next_path = np.add(next_path_segment);
-    assert_eq!(next_path.as_path().raw(), &[0, 255, 255, 255, 255, 255]);
 }

--- a/src/tests/compiler/clvm.rs
+++ b/src/tests/compiler/clvm.rs
@@ -1,16 +1,28 @@
-use std::borrow::Borrow;
-use std::rc::Rc;
+#[cfg(test)]
+use rand::prelude::*;
+#[cfg(test)]
+use rand::Rng;
+#[cfg(test)]
+use rand_chacha::ChaChaRng;
 
 use num_bigint::ToBigInt;
 
+use std::borrow::Borrow;
+use std::rc::Rc;
+
 use clvm_rs::allocator::Allocator;
 
+use crate::classic::clvm::__type_compatibility__::{bi_zero, bi_one};
+use crate::classic::clvm::casts::{bigint_to_bytes_clvm, bigint_to_bytes_unsigned};
 use crate::classic::clvm_tools::stages::stage_0::DefaultProgramRunner;
 
 use crate::compiler::clvm::parse_and_run;
 use crate::compiler::runtypes::RunFailure;
 use crate::compiler::sexp::{parse_sexp, SExp};
 use crate::compiler::srcloc::Srcloc;
+use crate::tests::classic::run::RandomClvmNumber;
+
+use crate::util::Number;
 
 fn test_compiler_clvm(to_run: &String, args: &String) -> Result<Rc<SExp>, RunFailure> {
     let mut allocator = Allocator::new();
@@ -137,4 +149,69 @@ fn test_clvm_4() {
     let want = parse_sexp(loc, &"(30000 . 3392)".to_string()).unwrap();
 
     assert!(result.equal_to(want[0].borrow()));
+}
+
+#[cfg(test)]
+fn does_number_need_extension_byte(n: Number) -> bool {
+    let mut iv = n.clone();
+    let eight_ones = 255_u32.to_bigint().unwrap();
+    while iv > eight_ones {
+        iv /= eight_ones.clone() + bi_one();
+    }
+    iv > 127_u32.to_bigint().unwrap()
+}
+
+// This seems like a reasonable way to unit test just the conversion functions
+// in a broad way i suppose.
+#[test]
+fn test_random_int_just_the_conversion_functions_and_no_other_things_from_the_stack_1() {
+    let mut rng = ChaChaRng::from_entropy();
+    for _ in 1..=200 {
+        let number_spec: RandomClvmNumber = rng.gen();
+
+        let to_bytes_clvm =
+            bigint_to_bytes_clvm(&number_spec.intended_value).unwrap().raw();
+        let to_bytes_unsigned =
+            if number_spec.intended_value < bi_zero() {
+                None
+            } else {
+                Some(bigint_to_bytes_unsigned(&number_spec.intended_value).unwrap().raw())
+            };
+
+        if number_spec.intended_value == bi_zero() {
+            assert!(to_bytes_clvm.is_empty());
+            if let Some(usbi) = &to_bytes_unsigned {
+                assert!(usbi.is_empty());
+            }
+            continue;
+        }
+
+        // Determine whether an extension byte would be needed.
+        let need_ext_byte = does_number_need_extension_byte(number_spec.intended_value.clone());
+        if need_ext_byte {
+            assert_eq!(to_bytes_clvm[0], 0);
+            if let Some(usbi) = &to_bytes_unsigned {
+                assert_eq!(usbi[0] & 0x80, 0x80);
+            }
+        }
+
+        // Check clvm repr
+        let one_byte_size = 256_u32.to_bigint().unwrap();
+        let mut check_value = number_spec.intended_value.clone();
+        for b in to_bytes_clvm.iter().rev() {
+            let isolated_byte = check_value.clone() & (one_byte_size.clone() - bi_one());
+            check_value >>= 8;
+            assert_eq!(isolated_byte, b.to_bigint().unwrap());
+        }
+
+        // Check unsigned repr
+        check_value = number_spec.intended_value.clone();
+        if let Some(usbi) = &to_bytes_unsigned {
+            for b in usbi.iter().rev() {
+                let isolated_byte = check_value.clone() & (one_byte_size.clone() - bi_one());
+                check_value >>= 8;
+                assert_eq!(isolated_byte, b.to_bigint().unwrap());
+            }
+        }
+    }
 }

--- a/src/tests/compiler/clvm.rs
+++ b/src/tests/compiler/clvm.rs
@@ -12,7 +12,7 @@ use std::rc::Rc;
 
 use clvm_rs::allocator::Allocator;
 
-use crate::classic::clvm::__type_compatibility__::{bi_zero, bi_one};
+use crate::classic::clvm::__type_compatibility__::{bi_one, bi_zero};
 use crate::classic::clvm::casts::{bigint_to_bytes_clvm, bigint_to_bytes_unsigned};
 use crate::classic::clvm_tools::stages::stage_0::DefaultProgramRunner;
 
@@ -169,14 +169,18 @@ fn test_random_int_just_the_conversion_functions_and_no_other_things_from_the_st
     for _ in 1..=200 {
         let number_spec: RandomClvmNumber = rng.gen();
 
-        let to_bytes_clvm =
-            bigint_to_bytes_clvm(&number_spec.intended_value).unwrap().raw();
-        let to_bytes_unsigned =
-            if number_spec.intended_value < bi_zero() {
-                None
-            } else {
-                Some(bigint_to_bytes_unsigned(&number_spec.intended_value).unwrap().raw())
-            };
+        let to_bytes_clvm = bigint_to_bytes_clvm(&number_spec.intended_value)
+            .unwrap()
+            .raw();
+        let to_bytes_unsigned = if number_spec.intended_value < bi_zero() {
+            None
+        } else {
+            Some(
+                bigint_to_bytes_unsigned(&number_spec.intended_value)
+                    .unwrap()
+                    .raw(),
+            )
+        };
 
         if number_spec.intended_value == bi_zero() {
             assert!(to_bytes_clvm.is_empty());

--- a/src/tests/compiler/clvm.rs
+++ b/src/tests/compiler/clvm.rs
@@ -169,17 +169,11 @@ fn test_random_int_just_the_conversion_functions_and_no_other_things_from_the_st
     for _ in 1..=200 {
         let number_spec: RandomClvmNumber = rng.gen();
 
-        let to_bytes_clvm = bigint_to_bytes_clvm(&number_spec.intended_value)
-            .unwrap()
-            .raw();
+        let to_bytes_clvm = bigint_to_bytes_clvm(&number_spec.intended_value).raw();
         let to_bytes_unsigned = if number_spec.intended_value < bi_zero() {
             None
         } else {
-            Some(
-                bigint_to_bytes_unsigned(&number_spec.intended_value)
-                    .unwrap()
-                    .raw(),
-            )
+            Some(bigint_to_bytes_unsigned(&number_spec.intended_value).raw())
         };
 
         if number_spec.intended_value == bi_zero() {


### PR DESCRIPTION
I feel like this is a simpler way of expressing what was happening here that's more clear, and fixes the bug, new tests added.