### PR TITLE
New clippy issues surfaced by new clippy

### DIFF
--- a/src/classic/clvm_tools/binutils.rs
+++ b/src/classic/clvm_tools/binutils.rs
@@ -102,18 +102,21 @@ pub fn ir_for_atom(atom: &Bytes, allow_keyword: bool) -> IRRepr {
 pub fn disassemble_to_ir_with_kw(
     allocator: &mut Allocator,
     sexp: NodePtr,
-    keyword_from_atom: &Record<Vec<u8>, String>,
-    allow_keyword_: bool,
+    // Due to an oversight in the original port, the user's
+    // kw_from_atom settings weren't honored, however they're
+    // never non-default in this code.  This deserves looking
+    // at, but isn't pressing at the moment.
+    _keyword_from_atom: &Record<Vec<u8>, String>,
+    mut allow_keyword: bool,
 ) -> IRRepr {
-    let mut allow_keyword = allow_keyword_;
     match allocator.sexp(sexp) {
         SExp::Pair(l, r) => {
             if let SExp::Pair(_, _) = allocator.sexp(l) {
                 allow_keyword = true;
             }
 
-            let v0 = disassemble_to_ir_with_kw(allocator, l, keyword_from_atom, allow_keyword);
-            let v1 = disassemble_to_ir_with_kw(allocator, r, keyword_from_atom, false);
+            let v0 = disassemble_to_ir_with_kw(allocator, l, _keyword_from_atom, allow_keyword);
+            let v1 = disassemble_to_ir_with_kw(allocator, r, _keyword_from_atom, false);
             IRRepr::Cons(Rc::new(v0), Rc::new(v1))
         }
 

--- a/src/classic/clvm_tools/stages/stage_2/inline.rs
+++ b/src/classic/clvm_tools/stages/stage_2/inline.rs
@@ -41,16 +41,12 @@ fn wrap_in_compile_time_list(allocator: &mut Allocator, code: NodePtr) -> Result
 
 // Create the sequence of individual tree moves that will translate to
 // (f ...) and (r ...) wrapping to select the given path from a larger structure.
-fn create_path_selection_plan(
-    allocator: &mut Allocator,
-    path: Number,
-    operators: &mut Vec<bool>,
-) -> Result<(), EvalErr> {
+fn create_path_selection_plan(path: Number, operators: &mut Vec<bool>) -> Result<(), EvalErr> {
     if path <= bi_one() {
         Ok(())
     } else {
         operators.push(path.clone() % 2_u32.to_bigint().unwrap() == bi_one());
-        create_path_selection_plan(allocator, path / 2_u32.to_bigint().unwrap(), operators)
+        create_path_selection_plan(path / 2_u32.to_bigint().unwrap(), operators)
     }
 }
 
@@ -62,7 +58,7 @@ fn wrap_path_selection(
 ) -> Result<NodePtr, EvalErr> {
     let mut operator_stack = Vec::new();
     let mut tail = wrapped;
-    create_path_selection_plan(allocator, path, &mut operator_stack)?;
+    create_path_selection_plan(path, &mut operator_stack)?;
     for o in operator_stack.iter() {
         let head_op = if *o { vec![6] } else { vec![5] };
         let head_atom = allocator.new_atom(&head_op)?;

--- a/src/classic/clvm_tools/stages/stage_2/optimize.rs
+++ b/src/classic/clvm_tools/stages/stage_2/optimize.rs
@@ -372,11 +372,7 @@ pub fn var_change_optimizer_cons_eval(
                                     SExp::Pair(val_first, _) => match allocator.sexp(val_first) {
                                         SExp::Atom(b) => {
                                             let vf_buf = allocator.buf(&b);
-                                            if vf_buf.len() != 1 || vf_buf[0] != 1 {
-                                                1
-                                            } else {
-                                                0
-                                            }
+                                            (vf_buf.len() != 1 || vf_buf[0] != 1) as i32
                                         }
                                         _ => 0,
                                     },

--- a/src/classic/platform/argparse.rs
+++ b/src/classic/platform/argparse.rs
@@ -1,5 +1,5 @@
 #![allow(
-    clippy::blacklisted_name,
+    clippy::disallowed_names,
     clippy::redundant_clone,
     clippy::trivially_copy_pass_by_ref
 )]

--- a/src/compiler/frontend.rs
+++ b/src/compiler/frontend.rs
@@ -88,7 +88,6 @@ fn collect_used_names_compileform(body: &CompileForm) -> Vec<Vec<u8>> {
 }
 
 fn calculate_live_helpers(
-    opts: Rc<dyn CompilerOpts>,
     last_names: &HashSet<Vec<u8>>,
     names: &HashSet<Vec<u8>>,
     helper_map: &HashMap<Vec<u8>, HelperForm>,
@@ -114,7 +113,7 @@ fn calculate_live_helpers(
             }
         }
 
-        calculate_live_helpers(opts, names, &needed_helpers, helper_map)
+        calculate_live_helpers(names, &needed_helpers, helper_map)
     }
 }
 
@@ -568,8 +567,7 @@ pub fn frontend(
         helper_map.insert(hpair.0.clone(), hpair.1.clone());
     }
 
-    let helper_names =
-        calculate_live_helpers(opts.clone(), &HashSet::new(), &expr_names, &helper_map);
+    let helper_names = calculate_live_helpers(&HashSet::new(), &expr_names, &helper_map);
 
     let mut live_helpers = Vec::new();
     for h in our_mod.helpers {

--- a/src/compiler/inline.rs
+++ b/src/compiler/inline.rs
@@ -156,7 +156,6 @@ fn get_inline_callable(
 
 #[allow(clippy::too_many_arguments)]
 fn replace_inline_body(
-    allocator: &mut Allocator,
     runner: Rc<dyn TRunProgram>,
     opts: Rc<dyn CompilerOpts>,
     compiler: &PrimaryCodegen,
@@ -177,7 +176,6 @@ fn replace_inline_body(
                     new_args.push(arg.clone());
                 } else {
                     let replaced = replace_inline_body(
-                        allocator,
                         runner.clone(),
                         opts.clone(),
                         compiler,
@@ -201,7 +199,6 @@ fn replace_inline_body(
                     let pass_on_args: Vec<Rc<BodyForm>> =
                         new_args.iter().skip(1).cloned().collect();
                     replace_inline_body(
-                        allocator,
                         runner,
                         opts.clone(),
                         compiler,
@@ -237,7 +234,6 @@ pub fn replace_in_inline(
     args: &[Rc<BodyForm>],
 ) -> Result<CompiledCode, CompileErr> {
     replace_inline_body(
-        allocator,
         runner.clone(),
         opts.clone(),
         compiler,


### PR DESCRIPTION
Clippy traffic.
I've been conservative in the classic compiler as a hedge against accidentally changing anything.  I think plumbing keyword_from_atom all the way down would be safe since it is the default, but I'm going to avoid making a semantically meaningful change off the cuff and round on it more thoroughly later.