### PR TITLE
Fix bugs in tail improper list parsing discovered earlier by fuzzing and now causing grief

### DIFF
--- a/src/compiler/frontend.rs
+++ b/src/compiler/frontend.rs
@@ -689,8 +689,6 @@ pub fn frontend(
     let mut includes = Vec::new();
     let started = frontend_start(opts.clone(), &mut includes, pre_forms)?;
 
-    eprintln!("pre_formst[0] {}", pre_forms[0]);
-
     for i in includes.iter() {
         started.add_include(i.clone());
     }

--- a/src/compiler/frontend.rs
+++ b/src/compiler/frontend.rs
@@ -689,6 +689,8 @@ pub fn frontend(
     let mut includes = Vec::new();
     let started = frontend_start(opts.clone(), &mut includes, pre_forms)?;
 
+    eprintln!("pre_formst[0] {}", pre_forms[0]);
+
     for i in includes.iter() {
         started.add_include(i.clone());
     }

--- a/src/compiler/sexp.rs
+++ b/src/compiler/sexp.rs
@@ -1,8 +1,8 @@
-#[cfg(any(test, feature = "fuzzer"))]
+#[cfg(test)]
 use rand::distributions::Standard;
-#[cfg(any(test, feature = "fuzzer"))]
+#[cfg(test)]
 use rand::prelude::Distribution;
-#[cfg(any(test, feature = "fuzzer"))]
+#[cfg(test)]
 use rand::Rng;
 
 use std::borrow::Borrow;
@@ -32,7 +32,7 @@ pub enum SExp {
     Atom(Srcloc, Vec<u8>),
 }
 
-#[cfg(any(test, feature = "fuzzer"))]
+#[cfg(test)]
 pub fn random_atom_name<R: Rng + ?Sized>(rng: &mut R, min_size: usize) -> Vec<u8> {
     let mut bytevec: Vec<u8> = Vec::new();
     let mut len = 0;
@@ -49,12 +49,12 @@ pub fn random_atom_name<R: Rng + ?Sized>(rng: &mut R, min_size: usize) -> Vec<u8
     bytevec
 }
 
-#[cfg(any(test, feature = "fuzzer"))]
+#[cfg(test)]
 pub fn random_atom<R: Rng + ?Sized>(rng: &mut R) -> SExp {
     SExp::Atom(Srcloc::start("*rng*"), random_atom_name(rng, 1))
 }
 
-#[cfg(any(test, feature = "fuzzer"))]
+#[cfg(test)]
 pub fn random_sexp<R: Rng + ?Sized>(rng: &mut R, remaining: usize) -> SExp {
     if remaining < 2 {
         random_atom(rng)
@@ -93,7 +93,7 @@ pub fn random_sexp<R: Rng + ?Sized>(rng: &mut R, remaining: usize) -> SExp {
 }
 
 // Thanks: https://stackoverflow.com/questions/48490049/how-do-i-choose-a-random-value-from-an-enum
-#[cfg(any(test, feature = "fuzzer"))]
+#[cfg(test)]
 impl Distribution<SExp> for Standard {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> SExp {
         random_sexp(rng, MAX_SEXP_COST)
@@ -685,8 +685,8 @@ fn parse_sexp_step(loc: Srcloc, p: &SExpParseState, this_char: u8) -> SExpParseR
                 }
                 (_, _) => match parse_sexp_step(loc.clone(), pp.borrow(), this_char) {
                     SExpParseResult::Emit(o, _p) => resume(SExpParseState::TermList(
-                        loc.clone(),
-                        Some(o.clone()),
+                        loc,
+                        Some(o),
                         pp.clone(),
                         list_content.clone(),
                     )),

--- a/src/compiler/sexp.rs
+++ b/src/compiler/sexp.rs
@@ -684,7 +684,7 @@ fn parse_sexp_step(loc: Srcloc, p: &SExpParseState, this_char: u8) -> SExpParseR
                     }
                 }
                 (_, _) => match parse_sexp_step(loc.clone(), pp.borrow(), this_char) {
-                    SExpParseResult::Emit(o, p) => resume(SExpParseState::TermList(
+                    SExpParseResult::Emit(o, _p) => resume(SExpParseState::TermList(
                         loc.clone(),
                         Some(o.clone()),
                         pp.clone(),

--- a/src/tests/compiler/compiler.rs
+++ b/src/tests/compiler/compiler.rs
@@ -1092,3 +1092,44 @@ fn test_modern_mod_form() {
 
     assert_eq!(result.to_string(), "7");
 }
+
+#[test]
+fn test_fuzz_seed_3956111146_1_alt_test_1() {
+    let res = run_string(
+        &"(mod () (include *standard-cl-21*) (q (r . lbvepvnoc) dbhk))".to_string(),
+        &"()".to_string(),
+    )
+    .unwrap();
+    assert_eq!(res.to_string(), "((r . lbvepvnoc) dbhk)");
+}
+
+#[test]
+fn test_fuzz_seed_3956111146_1() {
+    let res = run_string(
+        &"(mod () (include *standard-cl-21*) (q (r . lbvepvnoc) . dbhk))".to_string(),
+        &"()".to_string(),
+    )
+    .unwrap();
+    assert_eq!(res.to_string(), "((r . lbvepvnoc) . dbhk)");
+}
+
+#[test]
+fn arg_destructure_test_1() {
+    let prog = indoc! {"
+(mod
+  (
+      SINGLETON_MOD_HASH
+      LAUNCHER_HASH
+      launcher_id
+      . delegated_puzzle_hash
+  )
+
+  (include *standard-cl-21*)
+
+  delegated_puzzle_hash
+)"
+    }
+    .to_string();
+    let res = run_string(&prog, &"(1 2 3 . 4)".to_string()).unwrap();
+    assert_eq!(res.to_string(), "4");
+}


### PR DESCRIPTION
tail improper lists were not always parsed correctly in the modern parser and are now fixed.
tests are added for fuzzer outputs that triggered this bug and a user test case.