### PR TITLE
Include more tokens from macros since qq produces quoted atoms

### DIFF
--- a/src/compiler/frontend.rs
+++ b/src/compiler/frontend.rs
@@ -70,7 +70,13 @@ fn collect_used_names_bodyform(body: &BodyForm) -> Vec<Vec<u8>> {
 fn collect_used_names_helperform(body: &HelperForm) -> Vec<Vec<u8>> {
     match body {
         HelperForm::Defconstant(defc) => collect_used_names_bodyform(defc.body.borrow()),
-        HelperForm::Defmacro(mac) => collect_used_names_compileform(mac.program.borrow()),
+        HelperForm::Defmacro(mac) => {
+            let mut res = collect_used_names_compileform(mac.program.borrow());
+            // Ensure any other names mentioned in qq blocks are included.
+            let mut all_token_res = collect_used_names_sexp(mac.program.to_sexp());
+            res.append(&mut all_token_res);
+            res
+        },
         HelperForm::Defun(_, defun) => collect_used_names_bodyform(&defun.body),
     }
 }

--- a/src/compiler/frontend.rs
+++ b/src/compiler/frontend.rs
@@ -76,7 +76,7 @@ fn collect_used_names_helperform(body: &HelperForm) -> Vec<Vec<u8>> {
             let mut all_token_res = collect_used_names_sexp(mac.program.to_sexp());
             res.append(&mut all_token_res);
             res
-        },
+        }
         HelperForm::Defun(_, defun) => collect_used_names_bodyform(&defun.body),
     }
 }


### PR DESCRIPTION
Ensure that we capture functions specified to be called in quasiquotes.