### PR TITLE
20230103 inline diagnostic

### DIFF
--- a/src/compiler/codegen.rs
+++ b/src/compiler/codegen.rs
@@ -397,8 +397,9 @@ fn compile_call(
                 runner.clone(),
                 opts.clone(),
                 compiler,
-                l,
+                l.clone(),
                 &inline,
+                l,
                 &tl,
             ),
 
@@ -1105,6 +1106,7 @@ fn finalize_env_(
                             c,
                             l.clone(),
                             res,
+                            res.args.loc(),
                             &synthesize_args(res.args.clone()),
                         )
                         .map(|x| x.1),

--- a/src/compiler/inline.rs
+++ b/src/compiler/inline.rs
@@ -250,6 +250,7 @@ fn replace_inline_body(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn replace_in_inline(
     allocator: &mut Allocator,
     runner: Rc<dyn TRunProgram>,

--- a/src/tests/compiler/compiler.rs
+++ b/src/tests/compiler/compiler.rs
@@ -1158,7 +1158,7 @@ fn test_inline_out_of_bounds_diagnostic() {
     .to_string();
     let res = run_string(&prog, &"()".to_string());
     if let Err(CompileErr(l, e)) = res {
-        assert_eq!(l.line, 3);
+        assert_eq!(l.line, 4);
         assert!(e.starts_with("Lookup"));
     } else {
         assert!(false);

--- a/src/tests/compiler/compiler.rs
+++ b/src/tests/compiler/compiler.rs
@@ -1146,3 +1146,21 @@ fn test_defconstant_tree() {
     let res = run_string(&prog, &"()".to_string()).unwrap();
     assert_eq!(res.to_string(), "((0x4bf5122f344554c53bde2ebb8cd2b7e3d1600ad631c385a5d7cce23c7785459a . 0x9dcf97a184f32623d11a73124ceb99a5709b083721e878a16d78f596718ba7b2) 0x02a12871fee210fb8619291eaea194581cbd2531e4b23759d225f6806923f63222 . 0x02a8d5dd63fba471ebcb1f3e8f7c1e1879b7152a6e7298a91ce119a63400ade7c5)");
 }
+
+#[test]
+fn test_inline_out_of_bounds_diagnostic() {
+    let prog = indoc! {"
+(mod ()
+  (include *standard-cl-21*)
+  (defun-inline FOO (X Y) (+ X Y))
+  (FOO 3)
+  )"}
+    .to_string();
+    let res = run_string(&prog, &"()".to_string());
+    if let Err(CompileErr(l,e)) = res {
+        assert_eq!(l.line, 3);
+        assert!(e.starts_with("Lookup"));
+    } else {
+        assert!(false);
+    }
+}

--- a/src/tests/compiler/compiler.rs
+++ b/src/tests/compiler/compiler.rs
@@ -1157,7 +1157,7 @@ fn test_inline_out_of_bounds_diagnostic() {
   )"}
     .to_string();
     let res = run_string(&prog, &"()".to_string());
-    if let Err(CompileErr(l,e)) = res {
+    if let Err(CompileErr(l, e)) = res {
         assert_eq!(l.line, 3);
         assert!(e.starts_with("Lookup"));
     } else {


### PR DESCRIPTION
Provides a diagnostic for when an essential argument wasn't provided to an inline invocation.
Diagnostic names the callsite.

    (mod ()
      (include *standard-cl-21*)
      (defun-inline FOO (X Y) (+ X Y))
      (FOO 3)
      )

gives

    ./inline_diag.clsp(4):4-./inline_diag.clsp(4):7: Lookup for argument 2 that wasn't passed
