### PR TITLE
20230201 defconst

### DIFF
--- a/src/classic/clvm/sexp.rs
+++ b/src/classic/clvm/sexp.rs
@@ -491,6 +491,17 @@ pub fn flatten(allocator: &mut Allocator, tree_: NodePtr, res: &mut Vec<NodePtr>
     }
 }
 
+// Wrapper around last that properly bubbles the error into EvalErr for use in
+// the classic chialisp code.
+pub fn nonempty_last<X>(nil: NodePtr, lst: &[X]) -> Result<X, EvalErr>
+where
+    X: Copy,
+{
+    lst.last()
+        .copied()
+        .ok_or_else(|| EvalErr(nil, "alist is empty and shouldn't be".to_string()))
+}
+
 // This is a trait that generates a haskell-like ad-hoc type from the user's
 // construction of NodeSel and ThisNode.
 // the result is transformed into a NodeSel tree of NodePtr if it can be.

--- a/src/classic/clvm/sexp.rs
+++ b/src/classic/clvm/sexp.rs
@@ -490,3 +490,84 @@ pub fn flatten(allocator: &mut Allocator, tree_: NodePtr, res: &mut Vec<NodePtr>
         }
     }
 }
+
+// This is a trait that generates a haskell-like ad-hoc type from the user's
+// construction of NodeSel and ThisNode.
+// the result is transformed into a NodeSel tree of NodePtr if it can be.
+// The type of the result is an ad-hoc shape derived from the shape of the
+// original request.
+#[derive(Debug, Clone)]
+pub enum NodeSel<T, U> {
+    Cons(T, U),
+}
+
+#[derive(Debug, Clone)]
+pub enum First<T> {
+    Here(T),
+}
+
+#[derive(Debug, Clone)]
+pub enum Rest<T> {
+    Here(T),
+}
+
+#[derive(Debug, Clone)]
+pub enum ThisNode {
+    Here,
+}
+
+pub trait SelectNode<T, E> {
+    fn select_nodes(&self, allocator: &mut Allocator, n: NodePtr) -> Result<T, E>;
+}
+
+impl<E> SelectNode<NodePtr, E> for ThisNode {
+    fn select_nodes(&self, _allocator: &mut Allocator, n: NodePtr) -> Result<NodePtr, E> {
+        Ok(n)
+    }
+}
+
+impl<E> SelectNode<(), E> for () {
+    fn select_nodes(&self, _allocator: &mut Allocator, _n: NodePtr) -> Result<(), E> {
+        Ok(())
+    }
+}
+
+impl<R, T, E> SelectNode<First<T>, E> for First<R>
+where
+    R: SelectNode<T, E> + Clone,
+    E: From<EvalErr>,
+{
+    fn select_nodes(&self, allocator: &mut Allocator, n: NodePtr) -> Result<First<T>, E> {
+        let First::Here(f) = &self;
+        let NodeSel::Cons(first, ()) = NodeSel::Cons(f.clone(), ()).select_nodes(allocator, n)?;
+        Ok(First::Here(first))
+    }
+}
+
+impl<R, T, E> SelectNode<Rest<T>, E> for Rest<R>
+where
+    R: SelectNode<T, E> + Clone,
+    E: From<EvalErr>,
+{
+    fn select_nodes(&self, allocator: &mut Allocator, n: NodePtr) -> Result<Rest<T>, E> {
+        let Rest::Here(f) = &self;
+        let NodeSel::Cons((), rest) = NodeSel::Cons((), f.clone()).select_nodes(allocator, n)?;
+        Ok(Rest::Here(rest))
+    }
+}
+
+impl<R, S, T, U, E> SelectNode<NodeSel<T, U>, E> for NodeSel<R, S>
+where
+    R: SelectNode<T, E>,
+    S: SelectNode<U, E>,
+    E: From<EvalErr>,
+{
+    fn select_nodes(&self, allocator: &mut Allocator, n: NodePtr) -> Result<NodeSel<T, U>, E> {
+        let NodeSel::Cons(my_left, my_right) = &self;
+        let l = first(allocator, n)?;
+        let r = rest(allocator, n)?;
+        let first = my_left.select_nodes(allocator, l)?;
+        let rest = my_right.select_nodes(allocator, r)?;
+        Ok(NodeSel::Cons(first, rest))
+    }
+}

--- a/src/classic/clvm_tools/clvmc.rs
+++ b/src/classic/clvm_tools/clvmc.rs
@@ -76,7 +76,7 @@ pub fn detect_modern(allocator: &mut Allocator, sexp: NodePtr) -> Option<i32> {
     })
 }
 
-fn compile_clvm_text(
+pub fn compile_clvm_text(
     allocator: &mut Allocator,
     search_paths: &[String],
     symbol_table: &mut HashMap<String, String>,

--- a/src/classic/clvm_tools/clvmc.rs
+++ b/src/classic/clvm_tools/clvmc.rs
@@ -76,7 +76,7 @@ pub fn detect_modern(allocator: &mut Allocator, sexp: NodePtr) -> Option<i32> {
     })
 }
 
-pub fn compile_clvm_text(
+fn compile_clvm_text(
     allocator: &mut Allocator,
     search_paths: &[String],
     symbol_table: &mut HashMap<String, String>,

--- a/src/classic/clvm_tools/stages/stage_2/module.rs
+++ b/src/classic/clvm_tools/stages/stage_2/module.rs
@@ -7,8 +7,8 @@ use clvm_rs::reduction::EvalErr;
 
 use crate::classic::clvm::__type_compatibility__::{Bytes, BytesFromType};
 use crate::classic::clvm::sexp::{
-    enlist, first, flatten, fold_m, map_m, non_nil, proper_list, rest, First, Rest, SelectNode,
-    ThisNode,
+    enlist, first, flatten, fold_m, map_m, non_nil, nonempty_last, proper_list, rest, First, Rest,
+    SelectNode, ThisNode,
 };
 use crate::classic::clvm_tools::debug::build_symbol_dump;
 use crate::classic::clvm_tools::node_path::NodePath;
@@ -491,7 +491,7 @@ fn compile_mod_stage_1(
                     }
                 }
 
-                let uncompiled_main = alist[alist.len() - 1];
+                let uncompiled_main = nonempty_last(allocator.null(), &alist)?;
                 let main_list =
                     enlist(
                         allocator,

--- a/src/classic/clvm_tools/stages/stage_2/module.rs
+++ b/src/classic/clvm_tools/stages/stage_2/module.rs
@@ -153,12 +153,14 @@ fn build_used_constants_names(
     Ok(used_name_list)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn parse_include(
     allocator: &mut Allocator,
     name: NodePtr,
     namespace: &mut HashSet<Vec<u8>>,
     functions: &mut HashMap<Vec<u8>, NodePtr>,
     constants: &mut HashMap<Vec<u8>, NodePtr>,
+    delayed_constants: &mut HashMap<Vec<u8>, NodePtr>,
     macros: &mut Vec<(Vec<u8>, NodePtr)>,
     run_program: Rc<dyn TRunProgram>,
 ) -> Result<(), EvalErr> {
@@ -183,6 +185,7 @@ fn parse_include(
                         namespace,
                         functions,
                         constants,
+                        delayed_constants,
                         macros,
                         run_program.clone()
                     )?;
@@ -284,12 +287,17 @@ fn defun_inline_to_macro(
     Ok(res)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn parse_mod_sexp(
     allocator: &mut Allocator,
     declaration_sexp: NodePtr,
     namespace: &mut HashSet<Vec<u8>>,
     functions: &mut HashMap<Vec<u8>, NodePtr>,
     constants: &mut HashMap<Vec<u8>, NodePtr>,
+    // Delayed constants are new: they represent constant values
+    // but we need the whole module to evaluate them since they
+    // may call local functions (such as sha256tree).
+    delayed_constants: &mut HashMap<Vec<u8>, NodePtr>,
     macros: &mut Vec<(Vec<u8>, NodePtr)>,
     run_program: Rc<dyn TRunProgram>,
 ) -> Result<(), EvalErr> {
@@ -315,6 +323,7 @@ fn parse_mod_sexp(
                 namespace,
                 functions,
                 constants,
+                delayed_constants,
                 macros,
                 run_program.clone()
             )
@@ -327,30 +336,30 @@ fn parse_mod_sexp(
                 macros.push((name.to_vec(), declaration_sexp));
                 Ok(())
             } else if op == "defun".as_bytes() {
-                m! {
-                    declaration_sexp_r <- rest(allocator, declaration_sexp);
-                    declaration_sexp_rr <- rest(allocator, declaration_sexp_r);
-                    let _ = functions.insert(name, declaration_sexp_rr);
-                    Ok(())
-                }
+                let declaration_sexp_r = rest(allocator, declaration_sexp)?;
+                let declaration_sexp_rr = rest(allocator, declaration_sexp_r)?;
+                functions.insert(name, declaration_sexp_rr);
+                Ok(())
             } else if op == "defun-inline".as_bytes() {
-                m! {
-                    defined_macro <-
-                        defun_inline_to_macro(allocator, declaration_sexp);
-                    let _ = macros.push((name, defined_macro));
-                    Ok(())
-                }
+                let defined_macro =
+                        defun_inline_to_macro(allocator, declaration_sexp)?;
+                macros.push((name, defined_macro));
+                Ok(())
             } else if op == "defconstant".as_bytes() {
-                m! {
-                    r_of_declaration <- rest(allocator, declaration_sexp);
-                    rr_of_declaration <- rest(allocator, r_of_declaration);
-                    frr_of_declaration <- first(allocator, rr_of_declaration);
-                    quoted_decl <- quote(allocator, frr_of_declaration);
-                    let _ = constants.insert(name, quoted_decl);
-                    Ok(())
-                }
+                let r_of_declaration = rest(allocator, declaration_sexp)?;
+                let rr_of_declaration = rest(allocator, r_of_declaration)?;
+                let frr_of_declaration = first(allocator, rr_of_declaration)?;
+                let quoted_decl = quote(allocator, frr_of_declaration)?;
+                constants.insert(name, quoted_decl);
+                Ok(())
+            } else if op == "defconst".as_bytes() {
+                let r_of_declaration = rest(allocator, declaration_sexp)?;
+                let rr_of_declaration = rest(allocator, r_of_declaration)?;
+                let frr_of_declaration = first(allocator, rr_of_declaration)?;
+                delayed_constants.insert(name, frr_of_declaration);
+                Ok(())
             } else {
-                Err(EvalErr(declaration_sexp, "expected defun, defmacro, or defconstant".to_string()))
+                Err(EvalErr(declaration_sexp, "expected defun, defmacro, defconst, compile-file or defconstant".to_string()))
             }
         }
     }
@@ -359,12 +368,15 @@ fn parse_mod_sexp(
 fn compile_mod_stage_1(
     allocator: &mut Allocator,
     args: NodePtr,
+    macro_lookup: NodePtr,
     run_program: Rc<dyn TRunProgram>,
+    produce_extra_info: bool,
 ) -> Result<CollectionResult, EvalErr> {
     // stage 1: collect up names of globals (functions, constants, macros)
     m! {
         let mut functions = HashMap::new();
         let mut constants = HashMap::new();
+        let mut delayed_constants = HashMap::new();
         let mut macros = Vec::new();
         let mut namespace = HashSet::new();
 
@@ -385,26 +397,110 @@ fn compile_mod_stage_1(
                         &mut namespace,
                         &mut functions,
                         &mut constants,
+                        &mut delayed_constants,
                         &mut macros,
                         run_program.clone()
                     )?;
                 }
 
-                let uncompiled_main = alist[alist.len() - 1];
-                m! {
-                    main_list <-
-                        enlist(
-                            allocator,
-                            &[main_local_arguments, uncompiled_main]
+                // For each delayed constant, drain it into the
+                // main constant pool.
+                let mut result_collection = CollectionResult {
+                    functions,
+                    constants,
+                    macros
+                };
+
+                let main_name_vec = MAIN_NAME.as_bytes().to_vec();
+
+                // Process delayed constants until we either can't advance or
+                // they're all done.
+
+                loop {
+                    if delayed_constants.is_empty() {
+                        break;
+                    }
+
+                    let mut processed = false;
+                    // copy so we can modify delayed_constants.
+                    let delayed_constant_defs: Vec<(Vec<u8>, NodePtr)> =
+                        delayed_constants.iter().map(|(k,v)| (k.clone(), *v)).collect();
+
+                    for (name, delayed_body) in delayed_constant_defs.iter() {
+                        let main_list =
+                            enlist(
+                                allocator,
+                                &[allocator.null(), *delayed_body]
+                            )?;
+
+                        result_collection.functions.insert(
+                            main_name_vec.clone(), main_list
                         );
 
-                    let _ = functions.insert(MAIN_NAME.as_bytes().to_vec(), main_list);
-                    Ok(CollectionResult {
-                        functions,
-                        constants,
-                        macros
-                    })
+                        let used_in_this_constant = build_used_constants_names(
+                            allocator,
+                            &result_collection.functions,
+                            &delayed_constants,
+                            &result_collection.macros
+                        )?;
+
+                        let uses_other_constants = used_in_this_constant.iter().
+                            any(|u| delayed_constants.contains_key(u));
+
+                        if uses_other_constants {
+                            continue;
+                        }
+
+                        processed = true;
+
+                        let compiled =
+                            finish_compile_from_collection(
+                                allocator,
+                                macro_lookup,
+                                run_program.clone(),
+                                &result_collection,
+                                produce_extra_info
+                            )?;
+
+                        let compilation_result =
+                            run_program.run_program(
+                                allocator,
+                                compiled,
+                                allocator.null(),
+                                None
+                            )?;
+
+                        let result =
+                            run_program.run_program(
+                                allocator,
+                                compilation_result.1,
+                                allocator.null(),
+                                None
+                            )?;
+
+                        delayed_constants.remove(name);
+                        result_collection.constants.insert(
+                            name.to_vec(), quote(allocator, result.1)?
+                        );
+                    }
+
+                    if !processed {
+                        return Err(EvalErr(allocator.null(), "got stuck untangling defconst dependencies".to_string()));
+                    }
                 }
+
+                let uncompiled_main = alist[alist.len() - 1];
+                let main_list =
+                    enlist(
+                        allocator,
+                        &[main_local_arguments, uncompiled_main]
+                    )?;
+
+                result_collection.functions.insert(
+                    MAIN_NAME.as_bytes().to_vec(), main_list
+                );
+
+                Ok(result_collection)
             }
         }
     }
@@ -575,6 +671,102 @@ fn compile_functions(
     );
 }
 
+fn finish_compile_from_collection(
+    allocator: &mut Allocator,
+    macro_lookup: NodePtr,
+    run_program: Rc<dyn TRunProgram>,
+    cr: &CollectionResult,
+    produce_extra_info: bool,
+) -> Result<NodePtr, EvalErr> {
+    let a_atom = allocator.new_atom(&[2])?;
+    let cons_atom = allocator.new_atom(&[4])?;
+    let opt_atom = allocator.new_atom("opt".as_bytes())?;
+
+    // move macros into the macro lookup
+    let macro_lookup_program =
+        build_macro_lookup_program(allocator, macro_lookup, &cr.macros, run_program.clone())?;
+
+    // get a list of all symbols that are possibly used
+    let all_constants_names =
+        build_used_constants_names(allocator, &cr.functions, &cr.constants, &cr.macros)?;
+
+    let has_constants_tree = !all_constants_names.is_empty();
+    // build defuns table, with function names as keys
+
+    let constants_tree = build_tree(allocator, &all_constants_names)?;
+
+    let constants_root_node = NodePath::new(None).first();
+    let args_root_node = if has_constants_tree {
+        NodePath::new(None).rest()
+    } else {
+        NodePath::new(None)
+    };
+
+    let constants_symbol_table =
+        symbol_table_for_tree(allocator, constants_tree, &constants_root_node)?;
+
+    let compiled_functions = compile_functions(
+        allocator,
+        &cr.functions,
+        macro_lookup_program,
+        &constants_symbol_table,
+        &args_root_node,
+    )?;
+
+    let main_path = compiled_functions[MAIN_NAME.as_bytes()];
+
+    if has_constants_tree {
+        let mut all_constants_lookup = HashMap::new();
+        for (k, v) in compiled_functions {
+            if all_constants_names.contains(&k) {
+                all_constants_lookup.insert(k, v);
+            }
+        }
+
+        for (k, v) in cr.constants.iter() {
+            all_constants_lookup.insert(k.to_vec(), *v);
+        }
+
+        let all_constants_list = all_constants_names
+            .iter()
+            .filter_map(|name| all_constants_lookup.get(name))
+            .copied()
+            .collect::<Vec<NodePtr>>();
+
+        let all_constants_tree_program = build_tree_program(allocator, &all_constants_list)?;
+
+        let top_atom = allocator.new_atom(NodePath::new(None).as_path().data())?;
+        let arg_tree = enlist(
+            allocator,
+            &[cons_atom, all_constants_tree_program, top_atom],
+        )?;
+
+        let apply_list = enlist(allocator, &[a_atom, main_path, arg_tree])?;
+
+        let quoted_apply_list = quote(allocator, apply_list)?;
+        let opt_list = enlist(allocator, &[opt_atom, quoted_apply_list])?;
+
+        let symbols = build_symbol_dump(allocator, all_constants_lookup, run_program.clone())?;
+
+        let to_run = assemble(
+            allocator,
+            if produce_extra_info {
+                "(_set_symbol_table (c (c (q . \"source_file\") (_get_source_file)) 1))"
+            } else {
+                "(_set_symbol_table 1)"
+            },
+        )?;
+
+        run_program.run_program(allocator, to_run, symbols, None)?;
+
+        Ok(opt_list)
+    } else {
+        let top_atom = allocator.new_atom(NodePath::new(None).as_path().data())?;
+        let apply_list = enlist(allocator, &[a_atom, main_path, top_atom])?;
+        let quoted_apply_list = quote(allocator, apply_list)?;
+        enlist(allocator, &[opt_atom, quoted_apply_list])
+    }
+}
 pub fn compile_mod(
     allocator: &mut Allocator,
     args: NodePtr,
@@ -584,140 +776,28 @@ pub fn compile_mod(
     _level: usize,
 ) -> Result<NodePtr, EvalErr> {
     // Deal with the "mod" keyword.
-    m! {
-        produce_extra_info_prog <- assemble(allocator, "(_symbols_extra_info)");
-        let produce_extra_info_null = allocator.null();
-        extra_info_res <- run_program.run_program(
-            allocator,
-            produce_extra_info_prog,
-            produce_extra_info_null,
-            None
-        );
-        let produce_extra_info = non_nil(allocator, extra_info_res.1);
+    let produce_extra_info_prog = assemble(allocator, "(_symbols_extra_info)")?;
+    let produce_extra_info_null = allocator.null();
+    let extra_info_res = run_program.run_program(
+        allocator,
+        produce_extra_info_prog,
+        produce_extra_info_null,
+        None,
+    )?;
+    let produce_extra_info = non_nil(allocator, extra_info_res.1);
 
-        cr <- compile_mod_stage_1(allocator, args, run_program.clone());
-        a_atom <- allocator.new_atom(&[2]);
-        cons_atom <- allocator.new_atom(&[4]);
-        opt_atom <- allocator.new_atom("opt".as_bytes());
-
-        // move macros into the macro lookup
-        macro_lookup_program <- build_macro_lookup_program(
-            allocator, macro_lookup, &cr.macros, run_program.clone()
-        );
-
-        // get a list of all symbols that are possibly used
-        all_constants_names <- build_used_constants_names(
-            allocator, &cr.functions, &cr.constants, &cr.macros
-        );
-
-        let has_constants_tree = !all_constants_names.is_empty();
-        // build defuns table, with function names as keys
-
-        constants_tree <- build_tree(allocator, &all_constants_names);
-
-        let constants_root_node = NodePath::new(None).first();
-        let args_root_node =
-            if has_constants_tree {
-                NodePath::new(None).rest()
-            } else {
-                NodePath::new(None)
-            };
-
-        constants_symbol_table <- symbol_table_for_tree(
-            allocator, constants_tree, &constants_root_node
-        );
-
-        compiled_functions <- compile_functions(
-            allocator,
-            &cr.functions,
-            macro_lookup_program,
-            &constants_symbol_table,
-            &args_root_node,
-        );
-
-        let main_path = compiled_functions[MAIN_NAME.as_bytes()];
-
-        if has_constants_tree {
-            m! {
-                let mut all_constants_lookup = HashMap::new();
-                let _ = {
-                    for (k,v) in compiled_functions {
-                        if all_constants_names.contains(&k) {
-                            all_constants_lookup.insert(k, v);
-                        }
-                    }
-                };
-                let _ = {
-                    for (k,v) in cr.constants.iter() {
-                        all_constants_lookup.insert(k.to_vec(), *v);
-                    }
-                };
-
-                let all_constants_list =
-                    all_constants_names.iter().filter_map(
-                        |name| all_constants_lookup.get(name)
-                    ).copied().collect::<Vec<NodePtr>>();
-
-                all_constants_tree_program <-
-                    build_tree_program(allocator, &all_constants_list);
-
-                top_atom <- allocator.new_atom(NodePath::new(None).as_path().data());
-                arg_tree <-
-                    enlist(
-                        allocator,
-                        &[cons_atom, all_constants_tree_program, top_atom]
-                    );
-
-                apply_list <-
-                    enlist(
-                        allocator,
-                        &[a_atom, main_path, arg_tree]
-                    );
-                quoted_apply_list <- quote(allocator, apply_list);
-                opt_list <-
-                    enlist(
-                        allocator,
-                        &[opt_atom, quoted_apply_list]
-                    );
-
-                symbols <- build_symbol_dump(
-                    allocator,
-                    all_constants_lookup,
-                    run_program.clone()
-                );
-
-                to_run <- assemble(
-                    allocator,
-                    if produce_extra_info {
-                        "(_set_symbol_table (c (c (q . \"source_file\") (_get_source_file)) 1))"
-                    } else {
-                        "(_set_symbol_table 1)"
-                    }
-                );
-
-                _ <- run_program.run_program(
-                    allocator,
-                    to_run,
-                    symbols,
-                    None
-                );
-
-                Ok(opt_list)
-            }
-        } else {
-            m! {
-                top_atom <- allocator.new_atom(NodePath::new(None).as_path().data());
-                apply_list <-
-                    enlist(
-                        allocator,
-                        &[a_atom, main_path, top_atom]
-                    );
-                quoted_apply_list <- quote(allocator, apply_list);
-                enlist(
-                    allocator,
-                    &[opt_atom, quoted_apply_list]
-                )
-            }
-        }
-    }
+    let cr = compile_mod_stage_1(
+        allocator,
+        args,
+        macro_lookup,
+        run_program.clone(),
+        produce_extra_info,
+    )?;
+    finish_compile_from_collection(
+        allocator,
+        macro_lookup,
+        run_program,
+        &cr,
+        produce_extra_info,
+    )
 }

--- a/src/classic/clvm_tools/stages/stage_2/module.rs
+++ b/src/classic/clvm_tools/stages/stage_2/module.rs
@@ -7,7 +7,8 @@ use clvm_rs::reduction::EvalErr;
 
 use crate::classic::clvm::__type_compatibility__::{Bytes, BytesFromType};
 use crate::classic::clvm::sexp::{
-    enlist, first, flatten, fold_m, map_m, non_nil, proper_list, rest,
+    enlist, first, flatten, fold_m, map_m, non_nil, proper_list, rest, First, Rest, SelectNode,
+    ThisNode,
 };
 use crate::classic::clvm_tools::debug::build_symbol_dump;
 use crate::classic::clvm_tools::node_path::NodePath;
@@ -353,10 +354,11 @@ fn parse_mod_sexp(
                 constants.insert(name, quoted_decl);
                 Ok(())
             } else if op == "defconst".as_bytes() {
-                let r_of_declaration = rest(allocator, declaration_sexp)?;
-                let rr_of_declaration = rest(allocator, r_of_declaration)?;
-                let frr_of_declaration = first(allocator, rr_of_declaration)?;
-                delayed_constants.insert(name, frr_of_declaration);
+                // Use a new type-based match language.
+                let Rest::Here(Rest::Here(First::Here(definition))) =
+                    Rest::Here(Rest::Here(First::Here(ThisNode::Here))).
+                    select_nodes(allocator, declaration_sexp)?;
+                delayed_constants.insert(name, definition);
                 Ok(())
             } else {
                 Err(EvalErr(declaration_sexp, "expected defun, defmacro, defconst, compile-file or defconstant".to_string()))

--- a/src/compiler/comptypes.rs
+++ b/src/compiler/comptypes.rs
@@ -111,10 +111,17 @@ pub struct DefmacData {
 #[derive(Clone, Debug)]
 pub struct DefconstData {
     pub loc: Srcloc,
+    pub kind: ConstantKind,
     pub name: Vec<u8>,
     pub kw: Option<Srcloc>,
     pub nl: Srcloc,
     pub body: Rc<BodyForm>,
+}
+
+#[derive(Clone, Debug)]
+pub enum ConstantKind {
+    Complex,
+    Simple,
 }
 
 #[derive(Clone, Debug)]
@@ -340,14 +347,24 @@ impl HelperForm {
 
     pub fn to_sexp(&self) -> Rc<SExp> {
         match self {
-            HelperForm::Defconstant(defc) => Rc::new(list_to_cons(
-                defc.loc.clone(),
-                &[
-                    Rc::new(SExp::atom_from_string(defc.loc.clone(), "defconstant")),
-                    Rc::new(SExp::atom_from_vec(defc.loc.clone(), &defc.name)),
-                    defc.body.to_sexp(),
-                ],
-            )),
+            HelperForm::Defconstant(defc) => match defc.kind {
+                ConstantKind::Simple => Rc::new(list_to_cons(
+                    defc.loc.clone(),
+                    &[
+                        Rc::new(SExp::atom_from_string(defc.loc.clone(), "defconstant")),
+                        Rc::new(SExp::atom_from_vec(defc.loc.clone(), &defc.name)),
+                        defc.body.to_sexp(),
+                    ],
+                )),
+                ConstantKind::Complex => Rc::new(list_to_cons(
+                    defc.loc.clone(),
+                    &[
+                        Rc::new(SExp::atom_from_string(defc.loc.clone(), "defconst")),
+                        Rc::new(SExp::atom_from_vec(defc.loc.clone(), &defc.name)),
+                        defc.body.to_sexp(),
+                    ],
+                )),
+            },
             HelperForm::Defmacro(mac) => Rc::new(SExp::Cons(
                 mac.loc.clone(),
                 Rc::new(SExp::atom_from_string(mac.loc.clone(), "defmacro")),

--- a/src/compiler/evaluate.rs
+++ b/src/compiler/evaluate.rs
@@ -1253,6 +1253,7 @@ impl<'info> Evaluator {
         self.helpers.push(h.clone());
     }
 
+    // The evaluator treats the forms coming up from constants as live.
     fn get_constant(&self, name: &[u8]) -> Option<Rc<BodyForm>> {
         for h in self.helpers.iter() {
             if let HelperForm::Defconstant(defc) = h {

--- a/src/compiler/frontend.rs
+++ b/src/compiler/frontend.rs
@@ -5,8 +5,8 @@ use std::rc::Rc;
 
 use crate::classic::clvm::__type_compatibility__::bi_one;
 use crate::compiler::comptypes::{
-    list_to_cons, Binding, BodyForm, CompileErr, CompileForm, CompilerOpts, DefconstData,
-    DefmacData, DefunData, HelperForm, IncludeDesc, LetData, LetFormKind, ModAccum,
+    list_to_cons, Binding, BodyForm, CompileErr, CompileForm, CompilerOpts, ConstantKind,
+    DefconstData, DefmacData, DefunData, HelperForm, IncludeDesc, LetData, LetFormKind, ModAccum,
 };
 use crate::compiler::preprocessor::preprocess;
 use crate::compiler::rename::rename_children_compileform;
@@ -113,7 +113,6 @@ fn calculate_live_helpers(
                     .collect();
                 needed_helpers = needed_helpers
                     .union(&even_newer_names)
-                    .into_iter()
                     .map(|x| x.to_vec())
                     .collect();
             }
@@ -362,11 +361,31 @@ pub fn compile_bodyform(
     }
 }
 
+// More modern constant definition that interprets code ala constexpr.
+fn compile_defconst(
+    opts: Rc<dyn CompilerOpts>,
+    l: Srcloc,
+    nl: Srcloc,
+    kl: Option<Srcloc>,
+    name: Vec<u8>,
+    body: Rc<SExp>,
+) -> Result<HelperForm, CompileErr> {
+    let bf = compile_bodyform(opts, body)?;
+    Ok(HelperForm::Defconstant(DefconstData {
+        kw: kl,
+        nl,
+        loc: l,
+        kind: ConstantKind::Complex,
+        name: name.to_vec(),
+        body: Rc::new(bf),
+    }))
+}
+
 fn compile_defconstant(
     opts: Rc<dyn CompilerOpts>,
     l: Srcloc,
     nl: Srcloc,
-    kwl: Option<Srcloc>,
+    kl: Option<Srcloc>,
     name: Vec<u8>,
     body: Rc<SExp>,
 ) -> Result<HelperForm, CompileErr> {
@@ -375,7 +394,8 @@ fn compile_defconstant(
         Ok(HelperForm::Defconstant(DefconstData {
             loc: l,
             nl,
-            kw: kwl,
+            kw: kl,
+            kind: ConstantKind::Simple,
             name: name.to_vec(),
             body: Rc::new(BodyForm::Value(body_borrowed.clone())),
         }))
@@ -384,7 +404,8 @@ fn compile_defconstant(
             HelperForm::Defconstant(DefconstData {
                 loc: l,
                 nl,
-                kw: kwl,
+                kw: kl,
+                kind: ConstantKind::Simple,
                 name: name.to_vec(),
                 body: Rc::new(bf),
             })
@@ -526,6 +547,16 @@ pub fn compile_helperform(
     if let Some(matched) = body.proper_list().and_then(|pl| match_op_name_4(&pl)) {
         if matched.op_name == b"defconstant" {
             compile_defconstant(
+                opts,
+                l,
+                matched.nl,
+                Some(matched.opl),
+                matched.name.to_vec(),
+                matched.args,
+            )
+            .map(Some)
+        } else if matched.op_name == b"defconst" {
+            compile_defconst(
                 opts,
                 l,
                 matched.nl,
@@ -680,7 +711,8 @@ fn frontend_start(
 
                     if *mod_atom == "mod".as_bytes().to_vec() {
                         let args = Rc::new(x[1].clone());
-                        let body_vec = x.iter().skip(2).map(|s| Rc::new(s.clone())).collect();
+                        let body_vec: Vec<Rc<SExp>> =
+                            x.iter().skip(2).map(|s| Rc::new(s.clone())).collect();
                         let body = Rc::new(enlist(pre_forms[0].loc(), body_vec));
 
                         let ls = preprocess(opts.clone(), includes, body)?;

--- a/src/compiler/rename.rs
+++ b/src/compiler/rename.rs
@@ -262,6 +262,7 @@ fn rename_in_helperform(namemap: &HashMap<Vec<u8>, Vec<u8>>, h: &HelperForm) -> 
     match h {
         HelperForm::Defconstant(defc) => HelperForm::Defconstant(DefconstData {
             loc: defc.loc.clone(),
+            kind: defc.kind.clone(),
             name: defc.name.to_vec(),
             nl: defc.nl.clone(),
             kw: defc.kw.clone(),
@@ -293,6 +294,7 @@ fn rename_args_helperform(h: &HelperForm) -> HelperForm {
     match h {
         HelperForm::Defconstant(defc) => HelperForm::Defconstant(DefconstData {
             loc: defc.loc.clone(),
+            kind: defc.kind.clone(),
             nl: defc.nl.clone(),
             kw: defc.kw.clone(),
             name: defc.name.clone(),

--- a/src/tests/classic/run.rs
+++ b/src/tests/classic/run.rs
@@ -299,6 +299,7 @@ fn test_treehash_constant_embedded_classic() {
     ])
     .trim()
     .to_string();
+    assert_eq!(result_text, "(q . 0x6fcb06b1fe29d132bb37f3a21b86d7cf03d636bf6230aa206486bef5e68f9874)");
     let result_hash = do_basic_brun(&vec!["brun".to_string(), result_text, "()".to_string()])
         .trim()
         .to_string();
@@ -327,8 +328,9 @@ fn test_treehash_constant_embedded_fancy_order() {
         "}
         .to_string(),
     ])
-    .trim()
-    .to_string();
+        .trim()
+        .to_string();
+    assert_eq!(result_text, "(q . 0x6fcb06b1fe29d132bb37f3a21b86d7cf03d636bf6230aa206486bef5e68f98df)");
     let result_hash = do_basic_brun(&vec!["brun".to_string(), result_text, "()".to_string()])
         .trim()
         .to_string();
@@ -360,6 +362,7 @@ fn test_treehash_constant_embedded_fancy_order_from_fun() {
     ])
     .trim()
     .to_string();
+    assert_eq!(result_text, "(q . 0x6fcb06b1fe29d132bb37f3a21b86d7cf03d636bf6230aa206486bef5e68f98e0)");
     let result_hash = do_basic_brun(&vec!["brun".to_string(), result_text, "()".to_string()])
         .trim()
         .to_string();
@@ -410,6 +413,10 @@ fn test_treehash_constant_embedded_modern() {
     ])
     .trim()
     .to_string();
+    assert_eq!(
+        result_text,
+        "(2 (1 1 . 50565442356047746631413349885570059132562040184787699607120092457326103992436) (4 (1 2 (1 2 (3 (7 5) (1 2 (1 11 (1 . 2) (2 2 (4 2 (4 (5 5) ()))) (2 2 (4 2 (4 (6 5) ())))) 1) (1 2 (1 11 (1 . 1) 5) 1)) 1) 1) 1))"
+    );
     let result_hash = do_basic_brun(&vec!["brun".to_string(), result_text, "()".to_string()])
         .trim()
         .to_string();
@@ -439,6 +446,10 @@ fn test_treehash_constant_embedded_modern_fun() {
     ])
     .trim()
     .to_string();
+    assert_eq!(
+        result_text,
+        "(2 (1 2 6 (4 2 (4 (1 . 1) ()))) (4 (1 (2 (1 2 (3 (7 5) (1 2 (1 11 (1 . 2) (2 4 (4 2 (4 (5 5) ()))) (2 4 (4 2 (4 (6 5) ())))) 1) (1 2 (1 11 (1 . 1) 5) 1)) 1) 1) 2 (1 16 5 (1 . 50565442356047746631413349885570059132562040184787699607120092457326103992436)) 1) 1))".to_string()
+    );
     let result_hash = do_basic_brun(&vec!["brun".to_string(), result_text, "()".to_string()])
         .trim()
         .to_string();

--- a/src/tests/classic/run.rs
+++ b/src/tests/classic/run.rs
@@ -282,6 +282,107 @@ fn test_forms_of_destructuring_allowed_by_classic_1() {
 }
 
 #[test]
+fn test_treehash_constant_embedded_classic() {
+    let result_text = do_basic_run(&vec![
+        "run".to_string(),
+        "-i".to_string(),
+        "resources/tests".to_string(),
+        indoc! {"
+            (mod ()
+              (include sha256tree.clib)
+              (defconst H (+ G (sha256tree (q 2 3 4))))
+              (defconst G 1)
+              H
+              )
+        "}
+        .to_string(),
+    ])
+    .trim()
+    .to_string();
+    let result_hash = do_basic_brun(&vec!["brun".to_string(), result_text, "()".to_string()])
+        .trim()
+        .to_string();
+    assert_eq!(
+        result_hash,
+        "0x6fcb06b1fe29d132bb37f3a21b86d7cf03d636bf6230aa206486bef5e68f9874"
+    );
+}
+
+#[test]
+fn test_treehash_constant_embedded_classic_loop() {
+    let result_text = do_basic_run(&vec![
+        "run".to_string(),
+        "-i".to_string(),
+        "resources/tests".to_string(),
+        indoc! {"
+            (mod ()
+              (include sha256tree.clib)
+              (defconst H (+ G (sha256tree (q 2 3 4))))
+              (defconst G (logand H 1))
+              H
+              )
+        "}
+        .to_string(),
+    ])
+    .trim()
+    .to_string();
+    assert!(result_text.starts_with("FAIL"));
+    assert!(result_text.contains("got stuck untangling defconst dependencies"));
+}
+
+#[test]
+fn test_treehash_constant_embedded_modern() {
+    let result_text = do_basic_run(&vec![
+        "run".to_string(),
+        "-i".to_string(),
+        "resources/tests".to_string(),
+        indoc! {"
+            (mod ()
+              (include *standard-cl-21*)
+              (include sha256tree.clib)
+              (defconst H (+ G (sha256tree (q 2 3 4))))
+              (defconst G 1)
+              H
+              )
+        "}
+        .to_string(),
+    ])
+    .trim()
+    .to_string();
+    let result_hash = do_basic_brun(&vec!["brun".to_string(), result_text, "()".to_string()])
+        .trim()
+        .to_string();
+    assert_eq!(
+        result_hash,
+        "0x6fcb06b1fe29d132bb37f3a21b86d7cf03d636bf6230aa206486bef5e68f9874"
+    );
+}
+
+#[test]
+fn test_treehash_constant_embedded_modern_loop() {
+    let result_text = do_basic_run(&vec![
+        "run".to_string(),
+        "-i".to_string(),
+        "resources/tests".to_string(),
+        indoc! {"
+            (mod ()
+              (include *standard-cl-21*)
+              (include sha256tree.clib)
+              (defconst H (+ G (sha256tree (q 2 3 4))))
+              (defconst G (logand H 1))
+              H
+              )
+        "}
+        .to_string(),
+    ])
+    .trim()
+    .to_string();
+    eprintln!("{result_text}");
+    assert!(result_text.starts_with("*command*"));
+    assert!(result_text.contains("stack limit exceeded"));
+}
+
+#[test]
 fn test_num_encoding_just_less_than_5_bytes() {
     let res = do_basic_run(&vec!["run".to_string(), "4281419728".to_string()])
         .trim()

--- a/src/tests/classic/run.rs
+++ b/src/tests/classic/run.rs
@@ -309,6 +309,36 @@ fn test_treehash_constant_embedded_classic() {
 }
 
 #[test]
+fn test_treehash_constant_embedded_fancy_order() {
+    let result_text = do_basic_run(&vec![
+        "run".to_string(),
+        "-i".to_string(),
+        "resources/tests".to_string(),
+        indoc! {"
+            (mod ()
+              (include sha256tree.clib)
+              (defconst C 18)
+              (defconst H (+ C G (sha256tree (q 2 3 4))))
+              (defconst G (+ B A))
+              (defconst A 9)
+              (defconst B (* A A))
+              H
+              )
+        "}
+        .to_string(),
+    ])
+    .trim()
+    .to_string();
+    let result_hash = do_basic_brun(&vec!["brun".to_string(), result_text, "()".to_string()])
+        .trim()
+        .to_string();
+    assert_eq!(
+        result_hash,
+        "0x6fcb06b1fe29d132bb37f3a21b86d7cf03d636bf6230aa206486bef5e68f98df"
+    );
+}
+
+#[test]
 fn test_treehash_constant_embedded_classic_loop() {
     let result_text = do_basic_run(&vec![
         "run".to_string(),

--- a/src/tests/classic/run.rs
+++ b/src/tests/classic/run.rs
@@ -339,6 +339,37 @@ fn test_treehash_constant_embedded_fancy_order() {
 }
 
 #[test]
+fn test_treehash_constant_embedded_fancy_order_from_fun() {
+    let result_text = do_basic_run(&vec![
+        "run".to_string(),
+        "-i".to_string(),
+        "resources/tests".to_string(),
+        indoc! {"
+            (mod ()
+              (include sha256tree.clib)
+              (defconst C 18)
+              (defconst H (+ C G (sha256tree (q 2 3 4))))
+              (defconst G (+ B A))
+              (defconst A 9)
+              (defconst B (* A A))
+              (defun F (X) (+ X H))
+              (F 1)
+              )
+        "}
+        .to_string(),
+    ])
+    .trim()
+    .to_string();
+    let result_hash = do_basic_brun(&vec!["brun".to_string(), result_text, "()".to_string()])
+        .trim()
+        .to_string();
+    assert_eq!(
+        result_hash,
+        "0x6fcb06b1fe29d132bb37f3a21b86d7cf03d636bf6230aa206486bef5e68f98e0"
+    );
+}
+
+#[test]
 fn test_treehash_constant_embedded_classic_loop() {
     let result_text = do_basic_run(&vec![
         "run".to_string(),
@@ -385,6 +416,35 @@ fn test_treehash_constant_embedded_modern() {
     assert_eq!(
         result_hash,
         "0x6fcb06b1fe29d132bb37f3a21b86d7cf03d636bf6230aa206486bef5e68f9874"
+    );
+}
+
+#[test]
+fn test_treehash_constant_embedded_modern_fun() {
+    let result_text = do_basic_run(&vec![
+        "run".to_string(),
+        "-i".to_string(),
+        "resources/tests".to_string(),
+        indoc! {"
+            (mod ()
+              (include *standard-cl-21*)
+              (include sha256tree.clib)
+              (defconst H (+ G (sha256tree (q 2 3 4))))
+              (defconst G 1)
+              (defun F (X) (+ X H))
+              (F 1)
+              )
+        "}
+        .to_string(),
+    ])
+    .trim()
+    .to_string();
+    let result_hash = do_basic_brun(&vec!["brun".to_string(), result_text, "()".to_string()])
+        .trim()
+        .to_string();
+    assert_eq!(
+        result_hash,
+        "0x6fcb06b1fe29d132bb37f3a21b86d7cf03d636bf6230aa206486bef5e68f9875"
     );
 }
 

--- a/src/tests/classic/run.rs
+++ b/src/tests/classic/run.rs
@@ -299,7 +299,10 @@ fn test_treehash_constant_embedded_classic() {
     ])
     .trim()
     .to_string();
-    assert_eq!(result_text, "(q . 0x6fcb06b1fe29d132bb37f3a21b86d7cf03d636bf6230aa206486bef5e68f9874)");
+    assert_eq!(
+        result_text,
+        "(q . 0x6fcb06b1fe29d132bb37f3a21b86d7cf03d636bf6230aa206486bef5e68f9874)"
+    );
     let result_hash = do_basic_brun(&vec!["brun".to_string(), result_text, "()".to_string()])
         .trim()
         .to_string();
@@ -328,9 +331,12 @@ fn test_treehash_constant_embedded_fancy_order() {
         "}
         .to_string(),
     ])
-        .trim()
-        .to_string();
-    assert_eq!(result_text, "(q . 0x6fcb06b1fe29d132bb37f3a21b86d7cf03d636bf6230aa206486bef5e68f98df)");
+    .trim()
+    .to_string();
+    assert_eq!(
+        result_text,
+        "(q . 0x6fcb06b1fe29d132bb37f3a21b86d7cf03d636bf6230aa206486bef5e68f98df)"
+    );
     let result_hash = do_basic_brun(&vec!["brun".to_string(), result_text, "()".to_string()])
         .trim()
         .to_string();
@@ -362,7 +368,10 @@ fn test_treehash_constant_embedded_fancy_order_from_fun() {
     ])
     .trim()
     .to_string();
-    assert_eq!(result_text, "(q . 0x6fcb06b1fe29d132bb37f3a21b86d7cf03d636bf6230aa206486bef5e68f98e0)");
+    assert_eq!(
+        result_text,
+        "(q . 0x6fcb06b1fe29d132bb37f3a21b86d7cf03d636bf6230aa206486bef5e68f98e0)"
+    );
     let result_hash = do_basic_brun(&vec!["brun".to_string(), result_text, "()".to_string()])
         .trim()
         .to_string();


### PR DESCRIPTION
Adds a defconst form whose body is interpreted as chialisp and which has access to the functions defined in the parent program.
Mostly useful for calling sha256tree on constant values to pre-interpret them into compile time constants.
Constants can use other constants, but dependency loops aren't allowed.

            (mod ()
              (include sha256tree.clib)
              (defconst H (+ G (sha256tree (q 2 3 4))))
              (defconst G 1)
              H
              )

Because 

    $ opc -H '(2 3 4)'
    6fcb06b1fe29d132bb37f3a21b86d7cf03d636bf6230aa206486bef5e68f9873

this program compiles to

    (q . 0x6fcb06b1fe29d132bb37f3a21b86d7cf03d636bf6230aa206486bef5e68f9874)
