### PR TITLE
Fix the inline recursion check in inliner

### DIFF
--- a/src/compiler/inline.rs
+++ b/src/compiler/inline.rs
@@ -182,12 +182,35 @@ fn replace_inline_body(
         )),
         BodyForm::Call(l, call_args) => {
             let mut new_args = Vec::new();
+            // Ensure that we don't count branched invocations when checking
+            // each call downstream of the main expr is recursive.
+            //
+            // Previously, this program detected as recursive:
+            // (mod (A) ;; 11
+            //   (include *standard-cl-22*)
+            //   (defun-inline <= (A B) (not (> A B)))
+            //   (assign
+            //     foo (<= 2 A)
+            //     bar (<= 1 A)
+            //
+            //     baz (<= foo bar)
+            //
+            //     yorgle (<= baz bar)
+            //
+            //     (<= yorgle foo)
+            //     ))
+            //
+            // <= appears in the arguments, but isn't called recursively on itself.
+            // We ensure here that each argument has a separate visited stack.
+            // Recursion only happens when the same stack encounters an inline
+            // twice.
+            let mut new_visited = visited_inlines.clone();
             for (i, arg) in call_args.iter().enumerate() {
                 if i == 0 {
                     new_args.push(arg.clone());
                 } else {
                     let replaced = replace_inline_body(
-                        visited_inlines,
+                        &mut new_visited,
                         runner.clone(),
                         opts.clone(),
                         compiler,

--- a/src/tests/compiler/compiler.rs
+++ b/src/tests/compiler/compiler.rs
@@ -1150,6 +1150,32 @@ fn test_defconstant_tree() {
 }
 
 #[test]
+fn test_assign_dont_detect_unrelated_inlines_as_recursive() {
+    let prog = indoc! {"
+(mod (A) ;; 11
+  (include *standard-cl-22*)
+  (defun-inline <= (A B) (not (> A B)))
+  (let
+    ((foo (<= 2 A))
+     (bar (<= 1 A)))
+
+    (let
+      ((baz (<= foo bar)))
+
+      (let
+        ((yorgle (<= baz bar)))
+
+        (<= yorgle foo)
+        )
+      )
+    )
+  )"}
+    .to_string();
+    let res = run_string(&prog, &"(2)".to_string()).expect("should compile");
+    assert_eq!(res.to_string(), "1");
+}
+
+#[test]
 fn test_inline_out_of_bounds_diagnostic() {
     let prog = indoc! {"
 (mod ()


### PR DESCRIPTION
The recursion check in the inliner was checking for inlines present in the arguments to inline functions in the body of the inline and counting that as recursion even though it isn't.

Fix and add test.