### PR TITLE
Add the ability to name a function and lambda-ize it

### DIFF
--- a/src/compiler/codegen.rs
+++ b/src/compiler/codegen.rs
@@ -254,9 +254,7 @@ fn create_name_lookup(
                     // callable like a lambda by repeating the left env into it.
                     let find_program = Rc::new(SExp::Integer(l.clone(), i.to_bigint().unwrap()));
                     if as_variable && is_defun_in_codegen(compiler, name) {
-                        let lambda_ized = lambda_for_defun(l.clone(), find_program);
-                        eprintln!("lambda_ized {}: {}", decode_string(name), lambda_ized);
-                        lambda_ized
+                        lambda_for_defun(l.clone(), find_program)
                     } else {
                         find_program
                     }

--- a/src/compiler/codegen.rs
+++ b/src/compiler/codegen.rs
@@ -191,10 +191,7 @@ fn is_defun_in_codegen(compiler: &PrimaryCodegen, name: &[u8]) -> bool {
     false
 }
 
-fn make_list(
-    loc: Srcloc,
-    elements: Vec<Rc<SExp>>
-) -> Rc<SExp> {
+fn make_list(loc: Srcloc, elements: Vec<Rc<SExp>>) -> Rc<SExp> {
     let mut res = Rc::new(SExp::Nil(loc.clone()));
     for e in elements.iter().rev() {
         res = Rc::new(primcons(loc.clone(), e.clone(), res));
@@ -210,10 +207,7 @@ fn make_list(
 // Something like:
 //   (apply (quoted (expanded n)) (cons (quoted (expanded 2)) given-args))
 //
-fn lambda_for_defun(
-    loc: Srcloc,
-    lookup: Rc<SExp>
-) -> Rc<SExp> {
+fn lambda_for_defun(loc: Srcloc, lookup: Rc<SExp>) -> Rc<SExp> {
     let one_atom = Rc::new(SExp::Atom(loc.clone(), vec![1]));
     let two_atom = Rc::new(SExp::Atom(loc.clone(), vec![2]));
     let apply_atom = two_atom.clone();
@@ -221,25 +215,25 @@ fn lambda_for_defun(
     make_list(
         loc.clone(),
         vec![
-            Rc::new(primquote(loc.clone(), apply_atom.clone())),
+            Rc::new(primquote(loc.clone(), apply_atom)),
             Rc::new(primcons(
                 loc.clone(),
                 Rc::new(primquote(loc.clone(), one_atom.clone())),
-                lookup.clone()
+                lookup,
             )),
             make_list(
                 loc.clone(),
                 vec![
-                    Rc::new(primquote(loc.clone(), cons_atom.clone())),
+                    Rc::new(primquote(loc.clone(), cons_atom)),
                     Rc::new(primcons(
                         loc.clone(),
                         Rc::new(primquote(loc.clone(), one_atom.clone())),
-                        two_atom.clone()
+                        two_atom,
                     )),
-                    Rc::new(primquote(loc.clone(), one_atom.clone()))
-                ]
-            )
-        ]
+                    Rc::new(primquote(loc, one_atom)),
+                ],
+            ),
+        ],
     )
 }
 
@@ -247,15 +241,15 @@ fn create_name_lookup(
     compiler: &PrimaryCodegen,
     l: Srcloc,
     name: &[u8],
-    as_variable: bool
+    as_variable: bool,
 ) -> Result<Rc<SExp>, CompileErr> {
     compiler
         .constants
         .get(name)
         .map(|x| Ok(x.clone()))
         .unwrap_or_else(|| {
-            create_name_lookup_(l.clone(), name, compiler.env.clone(), compiler.env.clone())
-                .map(|i| {
+            create_name_lookup_(l.clone(), name, compiler.env.clone(), compiler.env.clone()).map(
+                |i| {
                     // Determine if it's a defun.  If so we can ensure that it's
                     // callable like a lambda by repeating the left env into it.
                     let find_program = Rc::new(SExp::Integer(l.clone(), i.to_bigint().unwrap()));
@@ -266,7 +260,8 @@ fn create_name_lookup(
                     } else {
                         find_program
                     }
-                })
+                },
+            )
         })
 }
 

--- a/src/compiler/codegen.rs
+++ b/src/compiler/codegen.rs
@@ -183,7 +183,7 @@ fn create_name_lookup_(
 fn is_defun_in_codegen(compiler: &PrimaryCodegen, name: &[u8]) -> bool {
     // Check for an input defun that matches the name.
     for h in compiler.orig_help.iter() {
-        if h.name() == name {
+        if matches!(h, HelperForm::Defun(false, _)) && h.name() == name {
             return true;
         }
     }

--- a/src/compiler/evaluate.rs
+++ b/src/compiler/evaluate.rs
@@ -13,7 +13,8 @@ use crate::compiler::clvm::run;
 use crate::compiler::codegen::codegen;
 use crate::compiler::compiler::is_at_capture;
 use crate::compiler::comptypes::{
-    Binding, BodyForm, CompileErr, CompileForm, CompilerOpts, DefunData, HelperForm, LetData, LetFormKind,
+    Binding, BodyForm, CompileErr, CompileForm, CompilerOpts, DefunData, HelperForm, LetData,
+    LetFormKind,
 };
 use crate::compiler::frontend::frontend;
 use crate::compiler::runtypes::RunFailure;
@@ -970,7 +971,7 @@ impl<'info> Evaluator {
         None
     }
 
-    fn create_mod_for_fun(&self, l: &Srcloc, function: Box<DefunData>) -> Rc<BodyForm> {
+    fn create_mod_for_fun(&self, l: &Srcloc, function: &DefunData) -> Rc<BodyForm> {
         Rc::new(BodyForm::Mod(
             l.clone(),
             CompileForm {
@@ -978,8 +979,8 @@ impl<'info> Evaluator {
                 include_forms: Vec::new(),
                 args: function.args.clone(),
                 helpers: self.helpers.clone(),
-                exp: function.body.clone()
-            }
+                exp: function.body.clone(),
+            },
         ))
     }
 
@@ -1053,14 +1054,14 @@ impl<'info> Evaluator {
                         literal_args,
                         only_inline,
                     )
-                } else if let Some(function) = self.get_function(&name) {
+                } else if let Some(function) = self.get_function(name) {
                     self.shrink_bodyform_visited(
                         allocator,
                         &mut visited,
                         prog_args,
                         env,
-                        self.create_mod_for_fun(&l, function),
-                        only_inline
+                        self.create_mod_for_fun(l, function.borrow()),
+                        only_inline,
                     )
                 } else {
                     env.get(name)

--- a/src/tests/compiler/compiler.rs
+++ b/src/tests/compiler/compiler.rs
@@ -1207,3 +1207,18 @@ fn test_treat_function_name_as_value() {
     let res = run_string(&prog, &"(99)".to_string()).expect("should compile");
     assert_eq!(res.to_string(), "200");
 }
+
+#[test]
+fn test_treat_function_name_as_value_filter() {
+    let prog = indoc! {"
+    (mod L
+     (include *standard-cl-21*)
+     (defun greater-than-3 (X) (> X 3))
+     (defun filter (F L) (let ((rest (filter F (r L)))) (if L (if (a F (list (f L))) (c (f L) rest) rest) ())))
+     (filter greater-than-3 L)
+    )
+    "}
+    .to_string();
+    let res = run_string(&prog, &"(1 2 3 4 5)".to_string()).expect("should compile");
+    assert_eq!(res.to_string(), "(4 5)");
+}

--- a/src/tests/compiler/compiler.rs
+++ b/src/tests/compiler/compiler.rs
@@ -1192,3 +1192,18 @@ fn test_inline_out_of_bounds_diagnostic() {
         assert!(false);
     }
 }
+
+#[test]
+fn test_treat_function_name_as_value() {
+    let prog = indoc! {"
+(mod (X)
+ (include *standard-cl-21*)
+ (defun G (X) (* 2 X))
+ (defun F (X) (G (+ 1 X)))
+ (a F (list X))
+)
+    "}
+    .to_string();
+    let res = run_string(&prog, &"(99)".to_string()).expect("should compile");
+    assert_eq!(res.to_string(), "200");
+}

--- a/src/tests/compiler/repl.rs
+++ b/src/tests/compiler/repl.rs
@@ -246,8 +246,8 @@ fn test_defun_value_in_repl_0() {
             "(defun greater-than-3 (X) (> X 3))",
             "(a greater-than-3 (list 5))"
         ])
-            .unwrap()
-            .unwrap(),
+        .unwrap()
+        .unwrap(),
         "(q . 1)"
     );
 }
@@ -260,8 +260,8 @@ fn test_defun_value_repl_map() {
             "(defun map (F L) (if L (c (a F (list (f L))) (map F (r L))) ()))",
             "(map greater-than-3 (list 1 2 3 4 5))"
         ])
-            .unwrap()
-            .unwrap(),
+        .unwrap()
+        .unwrap(),
         "(q () () () 1 1)"
     );
 }

--- a/src/tests/compiler/repl.rs
+++ b/src/tests/compiler/repl.rs
@@ -238,3 +238,30 @@ fn test_eval_less_than_forever_recursive() {
         "(q . 4)"
     );
 }
+
+#[test]
+fn test_defun_value_in_repl_0() {
+    assert_eq!(
+        test_repl_outcome(vec![
+            "(defun greater-than-3 (X) (> X 3))",
+            "(a greater-than-3 (list 5))"
+        ])
+            .unwrap()
+            .unwrap(),
+        "(q . 1)"
+    );
+}
+
+#[test]
+fn test_defun_value_repl_map() {
+    assert_eq!(
+        test_repl_outcome(vec![
+            "(defun greater-than-3 (X) (> X 3))",
+            "(defun map (F L) (if L (c (a F (list (f L))) (map F (r L))) ()))",
+            "(map greater-than-3 (list 1 2 3 4 5))"
+        ])
+            .unwrap()
+            .unwrap(),
+        "(q () () () 1 1)"
+    );
+}


### PR DESCRIPTION
traditional lisps don't allow functions defined by defun to have a value when referenced like a variable as in scheme, but that makes using defun functions as targets of map, reduce and such inconvenient.  This allows mentioning the name of a defun function to construct a callable whose arguments are the formal parameters of the function.

In particular, this works as one would expect it to: (a F (list X)) calls F with X and the environment containing G is as it is everywhere in the program.

    (mod (X)
     (include *standard-cl-21*)
     (defun G (X) (* 2 X))
     (defun F (X) (G (+ 1 X)))
     (a F (list X))
     )

Another example:

    (mod L
      (include *standard-cl-21*)
      (defun greater-than-3 (X) (> X 3))
      (defun filter (F L) (let ((rest (filter F (r L)))) (if L (if (a F (list (f L))) (c (f L) rest) rest) ())))
      (filter greater-than-3 L)
      )

