### PR TITLE
Add basic coverage scripts, to start doing some coverage testing

### DIFF
--- a/resources/coverage/distill_coverage_results.py
+++ b/resources/coverage/distill_coverage_results.py
@@ -1,0 +1,46 @@
+import json
+from pathlib import Path
+
+class CoverageResult:
+    def __init__(self):
+        self.info = {}
+
+    def add_file(self,path,name,obj):
+        target_path = path / name
+        self.info[str(target_path)] = obj
+
+    def show_result(self):
+        results = []
+        for filename in self.info.keys():
+            file_result_dict = {"name":filename}
+            for key in ['coveragePercent','linesCovered','linesMissed']:
+                file_result_dict[key] = self.info[filename][key]
+
+            results.append(file_result_dict)
+
+        return results
+
+def distill_coverage(result,path,container):
+    if not 'children' in container:
+        nice_cov_dict = {}
+        for item in ['coveragePercent','linesCovered','linesMissed']:
+            nice_cov_dict[item] = container[item]
+        result.add_file(path, path, nice_cov_dict)
+        return
+
+    for subpath in container['children'].keys():
+        distill_coverage(result, path / subpath, container['children'][subpath])
+
+if __name__ == '__main__':
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('covfile')
+    args = parser.parse_args()
+
+    result = CoverageResult()
+    infile = json.loads(open(args.covfile).read())
+    for root in infile['children'].keys():
+        distill_coverage(result, Path(root), infile['children'][root])
+
+    print(json.dumps(result.show_result(), indent=4))

--- a/resources/coverage/run_coverage.py
+++ b/resources/coverage/run_coverage.py
@@ -46,7 +46,28 @@ def collect_coverage():
     return list(filter(is_my_code, result.show_result()))
 
 if __name__ == '__main__':
+    import argparse
+    import sys
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--require-percent', help="required percentage to succeed", default=None)
+    args = parser.parse_args()
+
     delete_coverage_files()
     run_coverage_test()
     result = collect_coverage()
     print(json.dumps(result, indent=4))
+
+    if args.require_percent is not None:
+        required_percentage = int(args.require_percent)
+        has_required_pct = True
+
+        for file in result:
+            have_pct = int(file['coveragePercent'])
+            if have_pct < required_percentage:
+                print(f"{file['name']} lacks required coverage have {have_pct} want {required_percentage}")
+                has_required_pct = False
+
+        if not has_required_pct:
+            sys.exit(1)
+

--- a/resources/coverage/run_coverage.py
+++ b/resources/coverage/run_coverage.py
@@ -1,0 +1,46 @@
+import os
+import json
+import shutil
+import subprocess
+from pathlib import Path
+import distill_coverage_results
+
+env = dict(os.environ)
+env['RUSTFLAGS'] = "-C instrument-coverage"
+env['LLVM_PROFILE_FILE'] = "your_name-%p-%m.profraw"
+
+def get_profile_files(the_dir):
+    return list(filter(lambda x: x.endswith('.profraw'), os.listdir(the_dir)))
+
+def delete_coverage_files():
+    for the_file in get_profile_files('.'):
+        if the_file.endswith('.profraw'):
+            os.unlink(the_file)
+
+    try:
+        os.unlink('coverage.json')
+    except:
+        pass
+
+def run_coverage_test():
+    subprocess.check_call(['cargo','test'],env=env)
+
+def is_my_code(desc):
+    return not('.cargo' in desc['name']) and not('library/std' in desc['name'])
+
+def collect_coverage():
+    profile_files = get_profile_files('.')
+    args = ['grcov','--binary-path','target/debug','--output-type','covdir','--output-path','coverage.json'] + profile_files
+    subprocess.check_call(args)
+    result = distill_coverage_results.CoverageResult()
+
+    infile = json.loads(open('coverage.json').read())
+    for root in infile['children'].keys():
+        distill_coverage_results.distill_coverage(result, Path(root), infile['children'][root])
+    return list(filter(is_my_code, result.show_result()))
+
+if __name__ == '__main__':
+    delete_coverage_files()
+    run_coverage_test()
+    result = collect_coverage()
+    print(json.dumps(result, indent=4))

--- a/resources/coverage/run_coverage.py
+++ b/resources/coverage/run_coverage.py
@@ -9,6 +9,8 @@ env = dict(os.environ)
 env['RUSTFLAGS'] = "-C instrument-coverage"
 env['LLVM_PROFILE_FILE'] = "your_name-%p-%m.profraw"
 
+coverage_file = 'coverage.json'
+
 def get_profile_files(the_dir):
     return list(filter(lambda x: x.endswith('.profraw'), os.listdir(the_dir)))
 
@@ -18,7 +20,7 @@ def delete_coverage_files():
             os.unlink(the_file)
 
     try:
-        os.unlink('coverage.json')
+        os.unlink(coverage_file)
     except:
         pass
 
@@ -26,15 +28,15 @@ def run_coverage_test():
     subprocess.check_call(['cargo','test'],env=env)
 
 def is_my_code(desc):
-    return not('.cargo' in desc['name']) and not('library/std' in desc['name'])
+    return not('.cargo' in desc['name']) and not('library/std' in desc['name']) and not('src/classic/bins' in desc['name'])
 
 def collect_coverage():
     profile_files = get_profile_files('.')
-    args = ['grcov','--binary-path','target/debug','--output-type','covdir','--output-path','coverage.json'] + profile_files
+    args = ['grcov','--binary-path','target/debug','--output-type','covdir','--output-path',coverage_file] + profile_files
     subprocess.check_call(args)
     result = distill_coverage_results.CoverageResult()
 
-    infile = json.loads(open('coverage.json').read())
+    infile = json.loads(open(coverage_file).read())
     for root in infile['children'].keys():
         distill_coverage_results.distill_coverage(result, Path(root), infile['children'][root])
     return list(filter(is_my_code, result.show_result()))

--- a/resources/coverage/run_coverage.py
+++ b/resources/coverage/run_coverage.py
@@ -28,7 +28,11 @@ def run_coverage_test():
     subprocess.check_call(['cargo','test'],env=env)
 
 def is_my_code(desc):
-    return not('.cargo' in desc['name']) and not('library/std' in desc['name']) and not('src/classic/bins' in desc['name'])
+    for path in ['.cargo','library/std','src/py','src/classic/bins']:
+        if path in desc['name']:
+            return False
+
+    return True
 
 def collect_coverage():
     profile_files = get_profile_files('.')


### PR DESCRIPTION
run with ```python ./resources/coverage/run_coverage.py``` to get a json coverage report that's formatted for use in tools, but also should be pretty understandable.

gonna add analogs of the loose python tests and start ratcheting up coverage if this can be approved.

    [
        {
            "name": "/home/arty/dev/chia/clvm_tools_rs/src/classic/clvm/__type_compatibility__.rs",
            "coveragePercent": 58.51,
            "linesCovered": 189,
            "linesMissed": 134
        },
        {
            "name": "/home/arty/dev/chia/clvm_tools_rs/src/classic/clvm/casts.rs",
            "coveragePercent": 78.3,
            "linesCovered": 83,
            "linesMissed": 23
        },
        {
            "name": "/home/arty/dev/chia/clvm_tools_rs/src/classic/clvm/mod.rs",
            "coveragePercent": 100.0,
            "linesCovered": 6,
            "linesMissed": 0
        },
        {
            "name": "/home/arty/dev/chia/clvm_tools_rs/src/classic/clvm/serialize.rs",
            "coveragePercent": 73.02,
            "linesCovered": 138,
            "linesMissed": 51
        },
        {
            "name": "/home/arty/dev/chia/clvm_tools_rs/src/classic/clvm/sexp.rs",
            "coveragePercent": 66.9,
            "linesCovered": 194,
            "linesMissed": 96
        },
        {
            "name": "/home/arty/dev/chia/clvm_tools_rs/src/classic/clvm_tools/binutils.rs",
            "coveragePercent": 100.0,
            "linesCovered": 108,
            "linesMissed": 0
        },
        {
            "name": "/home/arty/dev/chia/clvm_tools_rs/src/classic/clvm_tools/clvmc.rs",
            "coveragePercent": 25.6,
            "linesCovered": 32,
            "linesMissed": 93
        },
    ...
    ]