### PR TITLE
20230410 compile file helpers 2

### DIFF
--- a/src/classic/clvm_tools/clvmc.rs
+++ b/src/classic/clvm_tools/clvmc.rs
@@ -44,6 +44,18 @@ fn include_dialect(
     None
 }
 
+pub fn write_sym_output(
+    compiled_lookup: &HashMap<String, String>,
+    path: &str,
+) -> Result<(), String> {
+    let output = serde_json::to_string(compiled_lookup)
+        .map_err(|_| "failed to serialize to json".to_string())?;
+
+    fs::write(path, output)
+        .map_err(|_| format!("failed to write {path}"))
+        .map(|_| ())
+}
+
 pub fn detect_modern(allocator: &mut Allocator, sexp: NodePtr) -> Option<i32> {
     let mut dialects = HashMap::new();
     dialects.insert("*standard-cl-21*".as_bytes().to_vec(), 21);
@@ -76,7 +88,7 @@ pub fn detect_modern(allocator: &mut Allocator, sexp: NodePtr) -> Option<i32> {
     })
 }
 
-fn compile_clvm_text(
+pub fn compile_clvm_text(
     allocator: &mut Allocator,
     search_paths: &[String],
     symbol_table: &mut HashMap<String, String>,

--- a/src/classic/clvm_tools/cmds.rs
+++ b/src/classic/clvm_tools/cmds.rs
@@ -27,7 +27,7 @@ use crate::classic::clvm::keyword_from_atom;
 use crate::classic::clvm::serialize::{sexp_from_stream, sexp_to_stream, SimpleCreateCLVMObject};
 use crate::classic::clvm::sexp::{enlist, proper_list, sexp_as_bin};
 use crate::classic::clvm_tools::binutils::{assemble_from_ir, disassemble, disassemble_with_kw};
-use crate::classic::clvm_tools::clvmc::detect_modern;
+use crate::classic::clvm_tools::clvmc::{detect_modern, write_sym_output};
 use crate::classic::clvm_tools::debug::check_unused;
 use crate::classic::clvm_tools::debug::{
     program_hash_from_program_env_cons, start_log_after, trace_pre_eval, trace_to_table,
@@ -767,18 +767,6 @@ fn fix_log(
                 log_result[i] = enlist(allocator, &updated).unwrap();
             })
         });
-    }
-}
-
-fn write_sym_output(compiled_lookup: &HashMap<String, String>, path: &str) -> Result<(), String> {
-    m! {
-        output <- serde_json::to_string(compiled_lookup).map_err(|_| {
-            "failed to serialize to json".to_string()
-        });
-
-        fs::write(path, output).map_err(|_| {
-            format!("failed to write {path}")
-        }).map(|_| ())
     }
 }
 

--- a/src/classic/clvm_tools/stages/stage_2/compile.rs
+++ b/src/classic/clvm_tools/stages/stage_2/compile.rs
@@ -9,11 +9,15 @@ use crate::classic::clvm::sexp::{enlist, first, map_m, non_nil, proper_list, res
 use crate::classic::clvm::{keyword_from_atom, keyword_to_atom};
 
 use crate::classic::clvm_tools::binutils::{assemble, disassemble};
+use crate::classic::clvm_tools::clvmc::{compile_clvm_text, write_sym_output};
 use crate::classic::clvm_tools::node_path::NodePath;
 use crate::classic::clvm_tools::stages::stage_0::TRunProgram;
 use crate::classic::clvm_tools::stages::stage_2::defaults::default_macro_lookup;
 use crate::classic::clvm_tools::stages::stage_2::helpers::{brun, evaluate, quote};
 use crate::classic::clvm_tools::stages::stage_2::module::compile_mod;
+use crate::classic::clvm_tools::stages::stage_2::reader::read_file;
+
+use crate::compiler::sexp::decode_string;
 
 const DIAG_OUTPUT: bool = false;
 
@@ -758,6 +762,29 @@ pub fn do_com_prog_for_dialect(
     }
 }
 
+pub fn get_compile_filename(
+    runner: Rc<dyn TRunProgram>,
+    allocator: &mut Allocator,
+) -> Result<Option<String>, EvalErr> {
+    let cvt_prog = assemble(allocator, "(_get_compile_filename)")?;
+
+    let cvt_prog_result = runner.run_program(allocator, cvt_prog, allocator.null(), None)?;
+
+    if cvt_prog_result.1 == allocator.null() {
+        return Ok(None);
+    }
+
+    if let SExp::Atom(buf) = allocator.sexp(cvt_prog_result.1) {
+        let abuf = allocator.buf(&buf).to_vec();
+        return Ok(Some(Bytes::new(Some(BytesFromType::Raw(abuf))).decode()));
+    }
+
+    Err(EvalErr(
+        allocator.null(),
+        "Couldn't decode result filename".to_string(),
+    ))
+}
+
 pub fn get_search_paths(
     runner: Rc<dyn TRunProgram>,
     allocator: &mut Allocator,
@@ -777,4 +804,87 @@ pub fn get_search_paths(
     }
 
     Ok(res)
+}
+
+pub fn get_last_path_component(name: &str) -> String {
+    let mut skip_start = None;
+    let fnbytes = name.as_bytes();
+
+    for (i, ch) in fnbytes.iter().enumerate() {
+        if *ch == b'/' || *ch == b'\\' {
+            skip_start = Some(i + 1);
+        }
+    }
+
+    if let Some(skip) = skip_start {
+        let namevec = fnbytes.iter().skip(skip).copied().collect();
+        Bytes::new(Some(BytesFromType::Raw(namevec))).decode()
+    } else {
+        name.to_owned()
+    }
+}
+
+pub fn make_symbols_name(current_filename: &str, name: &str) -> String {
+    // Grab the final path component if these strings are composed
+    // that way.
+    let take_start = get_last_path_component(current_filename);
+    let take_end = get_last_path_component(name);
+
+    format!("{take_start}_{take_end}.sym")
+}
+
+pub fn compile_file(
+    runner: Rc<dyn TRunProgram>,
+    allocator: &mut Allocator,
+    parent_sexp: NodePtr,
+    name: &str,
+    filename: &str,
+) -> Response {
+    let mut symtab = HashMap::new();
+    let current_filename = get_compile_filename(runner.clone(), allocator)?;
+    let file = read_file(runner, allocator, parent_sexp, filename)?;
+    let compiled = compile_clvm_text(
+        allocator,
+        &file.search_paths,
+        &mut symtab,
+        &decode_string(&file.data),
+        &file.full_path,
+    )?;
+
+    // Write symbols for the compiled inner module.
+    if let Some(filename) = current_filename {
+        let target_symbols_name = make_symbols_name(&filename, name);
+
+        // Not a hard error if we can't write the symbols,
+        // given the way most write chialisp.
+        write_sym_output(&symtab, &target_symbols_name).ok();
+    }
+
+    Ok(Reduction(1, compiled))
+}
+
+pub fn process_compile_file(
+    allocator: &mut Allocator,
+    runner: Rc<dyn TRunProgram>,
+    declaration_sexp: NodePtr,
+    name: Vec<u8>,
+) -> Result<(Vec<u8>, NodePtr), EvalErr> {
+    // A fancy include for the compilation result of a program.
+    let r_of_declaration = rest(allocator, declaration_sexp)?;
+    let rr_of_declaration = rest(allocator, r_of_declaration)?;
+    let frr_of_declaration = first(allocator, rr_of_declaration)?;
+    if let SExp::Atom(b) = allocator.sexp(frr_of_declaration) {
+        let b_name = allocator.buf(&b).to_vec();
+        let compiled_output = compile_file(
+            runner,
+            allocator,
+            declaration_sexp,
+            &Bytes::new(Some(BytesFromType::Raw(name.clone()))).decode(),
+            &Bytes::new(Some(BytesFromType::Raw(b_name))).decode(),
+        )?;
+
+        Ok((name, quote(allocator, compiled_output.1)?))
+    } else {
+        Err(EvalErr(declaration_sexp, "expected filename".to_string()))
+    }
 }

--- a/src/classic/clvm_tools/stages/stage_2/compile.rs
+++ b/src/classic/clvm_tools/stages/stage_2/compile.rs
@@ -9,15 +9,11 @@ use crate::classic::clvm::sexp::{enlist, first, map_m, non_nil, proper_list, res
 use crate::classic::clvm::{keyword_from_atom, keyword_to_atom};
 
 use crate::classic::clvm_tools::binutils::{assemble, disassemble};
-use crate::classic::clvm_tools::clvmc::{compile_clvm_text, write_sym_output};
 use crate::classic::clvm_tools::node_path::NodePath;
 use crate::classic::clvm_tools::stages::stage_0::TRunProgram;
 use crate::classic::clvm_tools::stages::stage_2::defaults::default_macro_lookup;
 use crate::classic::clvm_tools::stages::stage_2::helpers::{brun, evaluate, quote};
 use crate::classic::clvm_tools::stages::stage_2::module::compile_mod;
-use crate::classic::clvm_tools::stages::stage_2::reader::read_file;
-
-use crate::compiler::sexp::decode_string;
 
 const DIAG_OUTPUT: bool = false;
 
@@ -831,60 +827,4 @@ pub fn make_symbols_name(current_filename: &str, name: &str) -> String {
     let take_end = get_last_path_component(name);
 
     format!("{take_start}_{take_end}.sym")
-}
-
-pub fn compile_file(
-    runner: Rc<dyn TRunProgram>,
-    allocator: &mut Allocator,
-    parent_sexp: NodePtr,
-    name: &str,
-    filename: &str,
-) -> Response {
-    let mut symtab = HashMap::new();
-    let current_filename = get_compile_filename(runner.clone(), allocator)?;
-    let file = read_file(runner, allocator, parent_sexp, filename)?;
-    let compiled = compile_clvm_text(
-        allocator,
-        &file.search_paths,
-        &mut symtab,
-        &decode_string(&file.data),
-        &file.full_path,
-    )?;
-
-    // Write symbols for the compiled inner module.
-    if let Some(filename) = current_filename {
-        let target_symbols_name = make_symbols_name(&filename, name);
-
-        // Not a hard error if we can't write the symbols,
-        // given the way most write chialisp.
-        write_sym_output(&symtab, &target_symbols_name).ok();
-    }
-
-    Ok(Reduction(1, compiled))
-}
-
-pub fn process_compile_file(
-    allocator: &mut Allocator,
-    runner: Rc<dyn TRunProgram>,
-    declaration_sexp: NodePtr,
-    name: Vec<u8>,
-) -> Result<(Vec<u8>, NodePtr), EvalErr> {
-    // A fancy include for the compilation result of a program.
-    let r_of_declaration = rest(allocator, declaration_sexp)?;
-    let rr_of_declaration = rest(allocator, r_of_declaration)?;
-    let frr_of_declaration = first(allocator, rr_of_declaration)?;
-    if let SExp::Atom(b) = allocator.sexp(frr_of_declaration) {
-        let b_name = allocator.buf(&b).to_vec();
-        let compiled_output = compile_file(
-            runner,
-            allocator,
-            declaration_sexp,
-            &Bytes::new(Some(BytesFromType::Raw(name.clone()))).decode(),
-            &Bytes::new(Some(BytesFromType::Raw(b_name))).decode(),
-        )?;
-
-        Ok((name, quote(allocator, compiled_output.1)?))
-    } else {
-        Err(EvalErr(declaration_sexp, "expected filename".to_string()))
-    }
 }

--- a/src/classic/clvm_tools/stages/stage_2/operators.rs
+++ b/src/classic/clvm_tools/stages/stage_2/operators.rs
@@ -17,7 +17,7 @@ use crate::classic::clvm::keyword_from_atom;
 use crate::classic::clvm::sexp::proper_list;
 
 use crate::classic::clvm_tools::binutils::{
-    assemble_from_ir, disassemble, disassemble_to_ir_with_kw,
+    assemble_from_ir, disassemble_to_ir_with_kw,
 };
 use crate::classic::clvm_tools::ir::reader::read_ir;
 use crate::classic::clvm_tools::ir::writer::write_ir_to_stream;

--- a/src/classic/clvm_tools/stages/stage_2/operators.rs
+++ b/src/classic/clvm_tools/stages/stage_2/operators.rs
@@ -16,9 +16,7 @@ use crate::classic::clvm::__type_compatibility__::{Bytes, BytesFromType, Stream}
 use crate::classic::clvm::keyword_from_atom;
 use crate::classic::clvm::sexp::proper_list;
 
-use crate::classic::clvm_tools::binutils::{
-    assemble_from_ir, disassemble_to_ir_with_kw,
-};
+use crate::classic::clvm_tools::binutils::{assemble_from_ir, disassemble_to_ir_with_kw};
 use crate::classic::clvm_tools::ir::reader::read_ir;
 use crate::classic::clvm_tools::ir::writer::write_ir_to_stream;
 use crate::classic::clvm_tools::sha256tree::TreeHash;

--- a/src/classic/clvm_tools/stages/stage_2/operators.rs
+++ b/src/classic/clvm_tools/stages/stage_2/operators.rs
@@ -288,7 +288,6 @@ impl Dialect for CompilerOperatorsInternal {
         sexp: NodePtr,
         max_cost: Cost,
     ) -> Response {
-        eprintln!("op? {}", disassemble(allocator, op));
         match allocator.sexp(op) {
             SExp::Atom(opname) => {
                 let opbuf = allocator.buf(&opname);

--- a/src/tests/classic/stage_2.rs
+++ b/src/tests/classic/stage_2.rs
@@ -8,7 +8,7 @@ use crate::classic::clvm_tools::binutils::{assemble, assemble_from_ir, disassemb
 use crate::classic::clvm_tools::cmds::call_tool;
 use crate::classic::clvm_tools::ir::reader::read_ir;
 use crate::classic::clvm_tools::stages::stage_2::compile::{
-    do_com_prog, try_expand_macro_for_atom,
+    do_com_prog, get_compile_filename, get_last_path_component, try_expand_macro_for_atom,
 };
 use crate::classic::clvm_tools::stages::stage_2::helpers::{brun, evaluate, quote, run};
 use crate::classic::clvm_tools::stages::stage_2::operators::run_program_for_search_paths;
@@ -292,4 +292,23 @@ fn test_process_embed_file_as_hex() {
         decode_string(outstream.get_value().data())
     );
     assert_eq!(name, b"test-embed-from-hex");
+}
+
+#[test]
+fn test_classic_runner_has_compile_filename() {
+    let mut allocator = Allocator::new();
+    let use_filename = "test-classic-runner-has-compile-filename.clsp";
+    let runner = run_program_for_search_paths(use_filename, &vec![], false);
+
+    let result_filename = get_compile_filename(runner, &mut allocator)
+        .expect("should be able to tell us the file name given")
+        .expect("should have returned some");
+
+    assert_eq!(result_filename, use_filename);
+}
+
+#[test]
+fn test_get_last_path_component_0() {
+    let last_path_component = get_last_path_component("test/foo/bar.clsp");
+    assert_eq!(last_path_component, "bar.clsp");
 }


### PR DESCRIPTION
Move write_sym_output to src/classic/clvm_tools/clvmc from cmds.rs so it's in a sensible place to import from elsewhere.
Add get_compile_filename and get_last_path_component helpers which will eventually contribute to symbol output for inner compiles.
Add some basic smoke tests.