### PR TITLE
Add pub export for compile_clvm_text

### DIFF
--- a/src/classic/clvm/__type_compatibility__.rs
+++ b/src/classic/clvm/__type_compatibility__.rs
@@ -170,28 +170,6 @@ impl Bytes {
         Bytes::new(Some(BytesFromType::Raw(concat_bin)))
     }
 
-    pub fn slice(&self, start: usize, length: Option<usize>) -> Self {
-        let len = match length {
-            Some(x) => {
-                if self._b.len() > start + x {
-                    x
-                } else {
-                    self._b.len() - start
-                }
-            }
-            None => self._b.len() - start,
-        };
-        let mut ui8_clone = Vec::<u8>::with_capacity(len);
-        for i in start..start + len - 1 {
-            ui8_clone.push(self._b[i]);
-        }
-        Bytes::new(Some(BytesFromType::Raw(ui8_clone)))
-    }
-
-    pub fn subarray(&self, start: usize, length: Option<usize>) -> Self {
-        self.slice(start, length)
-    }
-
     pub fn data(&self) -> &Vec<u8> {
         &self._b
     }
@@ -229,51 +207,6 @@ impl Bytes {
             }
         }
         true
-    }
-
-    pub fn equal_to(&self, b: &Bytes) -> bool {
-        let slen = self._b.len();
-        let blen = b.length();
-        if slen != blen {
-            return false;
-        } else {
-            for i in 0..slen {
-                if b.at(i) != self._b[i] {
-                    return false;
-                }
-            }
-        }
-        true
-    }
-
-    /**
-     * Returns:
-     *   +1 if argument is smaller
-     *   0 if this and argument is the same
-     *   -1 if argument is larger
-     * @param other
-     */
-    pub fn compare(&self, other: Bytes) -> Ordering {
-        let slen = min(self._b.len(), other.length());
-
-        for i in 0..slen - 1 {
-            let diff: i32 = other.at(i) as i32 - self._b[i] as i32;
-            match (diff < 0, diff > 0) {
-                (true, _) => {
-                    return Ordering::Less;
-                }
-                (_, true) => {
-                    return Ordering::Greater;
-                }
-                _ => {}
-            }
-        }
-        if self._b.len() < slen {
-            return Ordering::Less;
-        } else if slen < other.length() {
-            return Ordering::Greater;
-        }
-        Ordering::Equal
     }
 }
 

--- a/src/classic/clvm_tools/clvmc.rs
+++ b/src/classic/clvm_tools/clvmc.rs
@@ -76,7 +76,7 @@ pub fn detect_modern(allocator: &mut Allocator, sexp: NodePtr) -> Option<i32> {
     })
 }
 
-fn compile_clvm_text(
+pub fn compile_clvm_text(
     allocator: &mut Allocator,
     search_paths: &[String],
     symbol_table: &mut HashMap<String, String>,

--- a/src/classic/clvm_tools/clvmc.rs
+++ b/src/classic/clvm_tools/clvmc.rs
@@ -88,9 +88,7 @@ pub fn compile_clvm_text(
 
     if let Some(dialect) = detect_modern(allocator, assembled_sexp) {
         let runner = Rc::new(DefaultProgramRunner::new());
-        let opts = opts
-            .set_optimize(true)
-            .set_frontend_opt(dialect > 21);
+        let opts = opts.set_optimize(true).set_frontend_opt(dialect > 21);
 
         let unopt_res = compile_file(allocator, runner.clone(), opts, text, symbol_table);
         let res = unopt_res.and_then(|x| run_optimizer(allocator, runner, Rc::new(x)));
@@ -140,7 +138,7 @@ pub fn compile_clvm(
     if compile {
         let text = fs::read_to_string(input_path)
             .map_err(|x| format!("error reading {input_path}: {x:?}"))?;
-        let opts = Rc::new(DefaultCompilerOpts::new(input_path)).set_search_paths(&search_paths);
+        let opts = Rc::new(DefaultCompilerOpts::new(input_path)).set_search_paths(search_paths);
 
         compile_clvm_inner(
             &mut allocator,

--- a/src/classic/clvm_tools/clvmc.rs
+++ b/src/classic/clvm_tools/clvmc.rs
@@ -78,6 +78,7 @@ pub fn detect_modern(allocator: &mut Allocator, sexp: NodePtr) -> Option<i32> {
 
 pub fn compile_clvm_text(
     allocator: &mut Allocator,
+    opts: Rc<dyn CompilerOpts>,
     search_paths: &[String],
     symbol_table: &mut HashMap<String, String>,
     text: &str,
@@ -88,7 +89,7 @@ pub fn compile_clvm_text(
 
     if let Some(dialect) = detect_modern(allocator, assembled_sexp) {
         let runner = Rc::new(DefaultProgramRunner::new());
-        let opts = Rc::new(DefaultCompilerOpts::new(input_path))
+        let opts = opts
             .set_optimize(true)
             .set_frontend_opt(dialect > 21)
             .set_search_paths(search_paths);
@@ -115,13 +116,14 @@ pub fn compile_clvm_text(
 
 pub fn compile_clvm_inner(
     allocator: &mut Allocator,
+    opts: Rc<dyn CompilerOpts>,
     search_paths: &[String],
     symbol_table: &mut HashMap<String, String>,
     filename: &str,
     text: &str,
     result_stream: &mut Stream,
 ) -> Result<(), String> {
-    let result = compile_clvm_text(allocator, search_paths, symbol_table, text, filename)
+    let result = compile_clvm_text(allocator, opts, search_paths, symbol_table, text, filename)
         .map_err(|x| format!("error {} compiling {}", x.1, disassemble(allocator, x.0)))?;
     sexp_to_stream(allocator, result, result_stream);
     Ok(())
@@ -144,6 +146,7 @@ pub fn compile_clvm(
 
         compile_clvm_inner(
             &mut allocator,
+            Rc::new(DefaultCompilerOpts::new(input_path)),
             search_paths,
             symbol_table,
             input_path,

--- a/src/classic/clvm_tools/stages/stage_2/operators.rs
+++ b/src/classic/clvm_tools/stages/stage_2/operators.rs
@@ -26,6 +26,8 @@ use crate::classic::clvm_tools::stages::stage_0::{
 use crate::classic::clvm_tools::stages::stage_2::compile::do_com_prog_for_dialect;
 use crate::classic::clvm_tools::stages::stage_2::optimize::do_optimize;
 
+use crate::compiler::comptypes::CompilerOpts;
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum AllocatorRefOrTreeHash {
     AllocatorRef(NodePtr),
@@ -50,6 +52,9 @@ pub struct CompilerOperatorsInternal {
     compile_outcomes: RefCell<HashMap<String, String>>,
     runner: RefCell<Rc<dyn TRunProgram>>,
     opt_memo: RefCell<HashMap<AllocatorRefOrTreeHash, NodePtr>>,
+    // A compiler opts as in the modern compiler.  If present, try using its
+    // file system interface to read files.
+    compiler_opts: RefCell<Option<Rc<dyn CompilerOpts>>>,
 }
 
 /// Given a list of search paths, find a full path to a file whose partial name
@@ -123,11 +128,13 @@ impl CompilerOperatorsInternal {
             compile_outcomes: RefCell::new(HashMap::new()),
             runner: RefCell::new(base_runner),
             opt_memo: RefCell::new(HashMap::new()),
+            compiler_opts: RefCell::new(None),
         }
     }
 
     pub fn neutralize(&self) {
         self.set_runner(Rc::new(DefaultProgramRunner::new()));
+        self.set_compiler_opts(None);
     }
 
     fn symbols_extra_info(&self, allocator: &mut Allocator) -> Response {
@@ -147,22 +154,44 @@ impl CompilerOperatorsInternal {
         borrow.clone()
     }
 
+    fn set_compiler_opts(&self, opts: Option<Rc<dyn CompilerOpts>>) {
+        self.compiler_opts.replace(opts);
+    }
+
+    fn get_compiler_opts(&self) -> Option<Rc<dyn CompilerOpts>> {
+        let borrow: Ref<'_, Option<Rc<dyn CompilerOpts>>> = self.compiler_opts.borrow();
+        borrow.clone()
+    }
+
     fn read(&self, allocator: &mut Allocator, sexp: NodePtr) -> Response {
+        // Given a string containing the data in the file to parse, parse it or
+        // return EvalErr.
+        let parse_file_content = |allocator: &mut Allocator, content: &String| {
+            read_ir(&content)
+                .map_err(|e| EvalErr(allocator.null(), e.to_string()))
+                .and_then(|ir| {
+                    assemble_from_ir(allocator, Rc::new(ir))
+                        .map(|ir_sexp| Reduction(1, ir_sexp))
+                })
+        };
+
         match allocator.sexp(sexp) {
             SExp::Pair(f, _) => match allocator.sexp(f) {
                 SExp::Atom(b) => {
                     let filename =
                         Bytes::new(Some(BytesFromType::Raw(allocator.buf(&b).to_vec()))).decode();
+                    // Use the read interface in CompilerOpts if we have one.
+                    if let Some(opts) = self.get_compiler_opts() {
+                        if let Ok((_, content)) = opts.read_new_file(self.source_file.clone(), filename.clone()) {
+                            return parse_file_content(allocator, &content);
+                        }
+                    }
+
+                    // Use the filesystem like normal if the opts couldn't find
+                    // the file.
                     fs::read_to_string(filename)
                         .map_err(|_| EvalErr(allocator.null(), "Failed to read file".to_string()))
-                        .and_then(|content| {
-                            read_ir(&content)
-                                .map_err(|e| EvalErr(allocator.null(), e.to_string()))
-                                .and_then(|ir| {
-                                    assemble_from_ir(allocator, Rc::new(ir))
-                                        .map(|ir_sexp| Reduction(1, ir_sexp))
-                                })
-                        })
+                        .and_then(|content| parse_file_content(allocator, &content))
                 }
                 _ => Err(EvalErr(
                     allocator.null(),
@@ -210,13 +239,23 @@ impl CompilerOperatorsInternal {
     }
 
     fn get_full_path_for_filename(&self, allocator: &mut Allocator, sexp: NodePtr) -> Response {
+        let convert_filename = |allocator: &mut Allocator, full_name: &String| {
+            let converted_filename = allocator.new_atom(full_name.as_bytes())?;
+            return Ok(Reduction(1, converted_filename));
+        };
+
         if let SExp::Pair(l, _r) = allocator.sexp(sexp) {
             if let SExp::Atom(b) = allocator.sexp(l) {
                 let filename =
                     Bytes::new(Some(BytesFromType::Raw(allocator.buf(&b).to_vec()))).decode();
+                // If we have a compiler opts injected, let that handle reading
+                // files.  The name will bubble up to the _read function.
+                if self.get_compiler_opts().is_some() {
+                    return convert_filename(allocator, &filename);
+                }
+
                 let full_name = full_path_for_filename(sexp, &filename, &self.search_paths)?;
-                let converted_filename = allocator.new_atom(full_name.as_bytes())?;
-                return Ok(Reduction(1, converted_filename));
+                return convert_filename(allocator, &full_name);
             }
         }
 
@@ -320,6 +359,10 @@ impl CompilerOperatorsInternal {
 impl CompilerOperators {
     pub fn get_compiles(&self) -> HashMap<String, String> {
         self.parent.get_compiles()
+    }
+
+    pub fn set_compiler_opts(&self, opts: Option<Rc<dyn CompilerOpts>>) {
+        self.parent.set_compiler_opts(opts);
     }
 }
 

--- a/wasm/src/api.rs
+++ b/wasm/src/api.rs
@@ -24,7 +24,7 @@ use clvm_tools_rs::compiler::clvm::{convert_to_clvm_rs, start_step};
 use clvm_tools_rs::compiler::compiler::{
     extract_program_and_env, path_to_function, rewrite_in_program, DefaultCompilerOpts,
 };
-use clvm_tools_rs::compiler::comptypes::CompileErr;
+use clvm_tools_rs::compiler::comptypes::{CompileErr, CompilerOpts};
 use clvm_tools_rs::compiler::prims;
 use clvm_tools_rs::compiler::repl::Repl;
 use clvm_tools_rs::compiler::runtypes::RunFailure;
@@ -310,9 +310,11 @@ pub fn compile(input_js: JsValue, filename_js: JsValue, search_paths_js: Vec<JsV
         .map(|j| j.as_string().unwrap())
         .collect();
 
+    let opts = Rc::new(DefaultCompilerOpts::new(&filename))
+        .set_search_paths(&search_paths);
     match compile_clvm_inner(
         &mut allocator,
-        &search_paths,
+        opts,
         &mut symbol_table,
         &filename,
         &input,

--- a/wasm/src/api.rs
+++ b/wasm/src/api.rs
@@ -319,6 +319,7 @@ pub fn compile(input_js: JsValue, filename_js: JsValue, search_paths_js: Vec<JsV
         &filename,
         &input,
         &mut result_stream,
+        false,
     ) {
         Ok(_) => make_compile_output(&result_stream, &symbol_table),
         Err(e) => create_clvm_runner_err(e),


### PR DESCRIPTION
Just add pub to compile_clvm_text to enable outside use of the main entrypoint.  it's a bit better for everything to bus through here.