### PR TITLE
Add tgz upload as well to be referenced by the vscode lsp build

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -265,7 +265,7 @@ jobs:
         AWS_SECRET_ACCESS_KEY: "${{ secrets.INSTALLER_UPLOAD_SECRET }}"
         AWS_REGION: us-west-2
       run: |
-        FILES=$(find . -type f -name '*.whl')
+        FILES=$(find . -type f -name '*.whl' -o -name '*.tar.gz')
         while IFS= read -r file; do
           filename=$(basename $file)
           aws --no-progress s3 cp "$file" "s3://download.chia.net/nightlies/clvm-tools-rs/$filename"


### PR DESCRIPTION
I think this will capture the built tgz source distribution for clvm_tools_rs onto the clvm_tools_rs nightly bucket.
the goal here is to have an artifact we're allowed to reference from the cargo build in https://github.com/Chia-Network/vscode-chialisp-lsp/blob/main/wasm/Cargo.toml, as such, a devops person needs to review this and tell me whether I'm on the right track.