### PR TITLE
Swap to build w/ docker instead of podman

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -59,8 +59,8 @@ jobs:
     - name: Build Linux in manylinux2010 with maturin on Python ${{ matrix.python }}
       if: startsWith(matrix.os, 'ubuntu')
       run: |
-        podman run --rm=true \
-          -v ${{ github.workspace }}:/ws:rw --workdir=/ws \
+        docker run --rm \
+          -v ${{ github.workspace }}:/ws --workdir=/ws \
           ghcr.io/chia-network/build-images/centos-pypa-rust-x86_64 \
           bash -exc '\
             yum -y install libc6 openssl-devel && \
@@ -181,7 +181,7 @@ jobs:
       run: |
         python support/wheelname.py
         python resources/tests/test-clvm-recompile-behavior.py
-        
+
     - name: Run tests from clvm
       run: |
         . ./activate


### PR DESCRIPTION
The repo to get podman installed on 20.04 is problematic. We have docker available though, so swapping podman -> docker to make the runners easier to manage.