### PR TITLE
20230618 specify wasm pack version

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -30,7 +30,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: install wasm-pack
-        run: cargo install wasm-pack
+        run: cargo install --version 0.11.1 wasm-pack
 
       - name: wasm-pack build and pack
         run: wasm-pack build --release --target=nodejs wasm && wasm-pack pack wasm


### PR DESCRIPTION
A new incompatible version of wasm-pack was released, so pin at the version that's compatible with what's in our cargo specs.