### PR TITLE
Fix yaml indent in m1 build

### DIFF
--- a/.github/workflows/build-m1-wheel.yml
+++ b/.github/workflows/build-m1-wheel.yml
@@ -78,7 +78,7 @@ jobs:
 
     - name: Install pytest
       run: |
-        . ./activate
+        . ./venv/bin/activate
         pip install pytest pytest-asyncio
 
 # Cost tests are currently failing.

--- a/.github/workflows/build-m1-wheel.yml
+++ b/.github/workflows/build-m1-wheel.yml
@@ -76,8 +76,8 @@ jobs:
         arch -arm64 python -c 'import clvm_tools; print(clvm_tools.__file__)'
         arch -arm64 python -c 'import clvm_tools_rs; print(clvm_tools_rs.__file__)'
 
-     - name: Install pytest
-       run: |
+    - name: Install pytest
+      run: |
         . ./activate
         pip install pytest pytest-asyncio
 

--- a/.github/workflows/build-m1-wheel.yml
+++ b/.github/workflows/build-m1-wheel.yml
@@ -92,7 +92,7 @@ jobs:
       run: |
         . ./venv/bin/activate
         cd clvm_tools
-        arch -arm64 python -m py.test 
+        arch -arm64 pytest
 
     - name: Upload wheels
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
Mis-indent in the m1 build file.  Missed because syntax errors aren't hard errors in the PR submission, apologies.