### PR TITLE
Pass through op extension

### DIFF
--- a/src/classic/clvm_tools/stages/stage_2/operators.rs
+++ b/src/classic/clvm_tools/stages/stage_2/operators.rs
@@ -340,7 +340,7 @@ impl Dialect for CompilerOperatorsInternal {
         op: NodePtr,
         sexp: NodePtr,
         max_cost: Cost,
-        _extension: OperatorSet,
+        extension: OperatorSet,
     ) -> Response {
         match allocator.sexp(op) {
             SExp::Atom() => {
@@ -368,12 +368,12 @@ impl Dialect for CompilerOperatorsInternal {
                     self.get_source_file(allocator)
                 } else {
                     self.base_dialect
-                        .op(allocator, op, sexp, max_cost, OperatorSet::BLS)
+                        .op(allocator, op, sexp, max_cost, extension)
                 }
             }
             _ => self
                 .base_dialect
-                .op(allocator, op, sexp, max_cost, OperatorSet::BLS),
+                .op(allocator, op, sexp, max_cost, extension),
         }
     }
 


### PR DESCRIPTION
Apologies, i missed this.  We should pass through the operators set.  It's at compile time and so different from runtime.  I was thinking that the operator set should be stable, but we should have it be uniform up and down.