### PR TITLE
20230731 base rest

### DIFF
--- a/src/compiler/cldb.rs
+++ b/src/compiler/cldb.rs
@@ -157,6 +157,7 @@ impl CldbRun {
 
         match &new_step {
             Ok(RunStep::OpResult(l, x, _p)) => {
+                eprintln!("OpResult {x}");
                 if self.in_expr {
                     self.to_print
                         .insert("Result-Location".to_string(), l.to_string());

--- a/src/compiler/cldb.rs
+++ b/src/compiler/cldb.rs
@@ -157,7 +157,6 @@ impl CldbRun {
 
         match &new_step {
             Ok(RunStep::OpResult(l, x, _p)) => {
-                eprintln!("OpResult {x}");
                 if self.in_expr {
                     self.to_print
                         .insert("Result-Location".to_string(), l.to_string());

--- a/src/compiler/comptypes.rs
+++ b/src/compiler/comptypes.rs
@@ -389,7 +389,17 @@ pub struct CallSpec<'a> {
     pub original: Rc<BodyForm>,
 }
 
-/// A pair of arguments and an optional tail for function calls.
+/// Raw callspec for use in codegen.
+#[derive(Debug, Clone)]
+pub struct RawCallSpec<'a> {
+    pub loc: Srcloc,
+    pub args: &'a [Rc<BodyForm>],
+    pub tail: Option<Rc<BodyForm>>,
+    pub original: Rc<BodyForm>,
+}
+
+/// A pair of arguments and an optional tail for function calls.  The tail is
+/// a function tail given by a final &rest argument.
 #[derive(Debug, Default, Clone)]
 pub struct ArgsAndTail {
     pub args: Vec<Rc<BodyForm>>,

--- a/src/compiler/comptypes.rs
+++ b/src/compiler/comptypes.rs
@@ -142,7 +142,7 @@ pub enum BodyForm {
     ///
     /// So tail improper calls aren't allowed.  In real lisp, (apply ...) can
     /// generate them if needed.
-    Call(Srcloc, Vec<Rc<BodyForm>>),
+    Call(Srcloc, Vec<Rc<BodyForm>>, Option<Rc<BodyForm>>),
     /// (mod ...) can be used in chialisp as an expression, in which it returns
     /// the compiled code.  Here, it contains a CompileForm, which represents
     /// the full significant input of a program (yielded by frontend()).
@@ -379,6 +379,23 @@ pub struct ModAccum {
     pub exp_form: Option<CompileForm>,
 }
 
+/// A specification of a function call including elements useful for evaluation.
+#[derive(Debug, Clone)]
+pub struct CallSpec<'a> {
+    pub loc: Srcloc,
+    pub name: &'a [u8],
+    pub args: &'a [Rc<BodyForm>],
+    pub tail: Option<Rc<BodyForm>>,
+    pub original: Rc<BodyForm>,
+}
+
+/// A pair of arguments and an optional tail for function calls.
+#[derive(Debug, Default, Clone)]
+pub struct ArgsAndTail {
+    pub args: Vec<Rc<BodyForm>>,
+    pub tail: Option<Rc<BodyForm>>,
+}
+
 impl ModAccum {
     pub fn set_final(&self, c: &CompileForm) -> Self {
         ModAccum {
@@ -568,7 +585,7 @@ impl BodyForm {
         match self {
             BodyForm::Let(_, letdata) => letdata.loc.clone(),
             BodyForm::Quoted(a) => a.loc(),
-            BodyForm::Call(loc, _) => loc.clone(),
+            BodyForm::Call(loc, _, _) => loc.clone(),
             BodyForm::Value(a) => a.loc(),
             BodyForm::Mod(kl, program) => kl.ext(&program.loc),
         }
@@ -609,8 +626,12 @@ impl BodyForm {
                 Rc::new(body.clone()),
             )),
             BodyForm::Value(body) => Rc::new(body.clone()),
-            BodyForm::Call(loc, exprs) => {
-                let converted: Vec<Rc<SExp>> = exprs.iter().map(|x| x.to_sexp()).collect();
+            BodyForm::Call(loc, exprs, tail) => {
+                let mut converted: Vec<Rc<SExp>> = exprs.iter().map(|x| x.to_sexp()).collect();
+                if let Some(t) = tail.as_ref() {
+                    converted.push(Rc::new(SExp::Atom(t.loc(), "&rest".as_bytes().to_vec())));
+                    converted.push(t.to_sexp());
+                }
                 Rc::new(list_to_cons(loc.clone(), &converted))
             }
             BodyForm::Mod(loc, program) => Rc::new(SExp::Cons(

--- a/src/compiler/evaluate.rs
+++ b/src/compiler/evaluate.rs
@@ -13,7 +13,7 @@ use crate::compiler::clvm::run;
 use crate::compiler::codegen::codegen;
 use crate::compiler::compiler::is_at_capture;
 use crate::compiler::comptypes::{
-    Binding, BodyForm, CompileErr, CompileForm, CompilerOpts, HelperForm, LetData, LetFormKind,
+    ArgsAndTail, Binding, BodyForm, CallSpec, CompileErr, CompileForm, CompilerOpts, HelperForm, LetData, LetFormKind,
 };
 use crate::compiler::frontend::frontend;
 use crate::compiler::runtypes::RunFailure;
@@ -134,6 +134,7 @@ fn make_operator1(l: &Srcloc, op: String, arg: Rc<BodyForm>) -> BodyForm {
             Rc::new(BodyForm::Value(SExp::atom_from_string(l.clone(), &op))),
             arg,
         ],
+        None,
     )
 }
 
@@ -145,6 +146,7 @@ fn make_operator2(l: &Srcloc, op: String, arg1: Rc<BodyForm>, arg2: Rc<BodyForm>
             arg1,
             arg2,
         ],
+        None,
     )
 }
 
@@ -267,9 +269,11 @@ fn arg_inputs_primitive(arginputs: Rc<ArgInputs>) -> bool {
 fn build_argument_captures(
     l: &Srcloc,
     arguments_to_convert: &[Rc<BodyForm>],
+    tail: Option<Rc<BodyForm>>,
     args: Rc<SExp>,
 ) -> Result<HashMap<Vec<u8>, Rc<BodyForm>>, CompileErr> {
-    let mut formed_arguments = ArgInputs::Whole(Rc::new(BodyForm::Quoted(SExp::Nil(l.clone()))));
+    let formed_tail = tail.unwrap_or_else(|| Rc::new(BodyForm::Quoted(SExp::Nil(l.clone()))));
+    let mut formed_arguments = ArgInputs::Whole(formed_tail);
 
     for i_reverse in 0..arguments_to_convert.len() {
         let i = arguments_to_convert.len() - i_reverse - 1;
@@ -375,6 +379,7 @@ fn synthesize_args(
                         synthesize_args(f.clone(), env)?,
                         synthesize_args(r.clone(), env)?,
                     ],
+                    None,
                 )))
             }
         }
@@ -418,7 +423,8 @@ fn is_cons_atom(h: Rc<SExp>) -> bool {
 }
 
 fn match_cons(args: Rc<BodyForm>) -> Option<(Rc<BodyForm>, Rc<BodyForm>)> {
-    if let BodyForm::Call(_, v) = args.borrow() {
+    // Since this matches a primitve, there's no alternative for a tail.
+    if let BodyForm::Call(_, v, None) = args.borrow() {
         if v.len() < 3 {
             return None;
         }
@@ -487,6 +493,7 @@ fn choose_from_env_by_path(path_: Number, args_program: Rc<BodyForm>) -> Rc<Body
                     ))),
                     result_form,
                 ],
+                None,
             ));
         }
     }
@@ -506,7 +513,7 @@ fn promote_program_to_bodyform(
 
             // Process tails to change bare numbers to (@ n)
             let args = promote_args_to_bodyform(h.clone(), t.clone(), env)?;
-            Ok(Rc::new(BodyForm::Call(program.loc(), args)))
+            Ok(Rc::new(BodyForm::Call(program.loc(), args, None)))
         }
         SExp::Integer(_, n) => {
             // A program that is an atom refers to a position
@@ -531,7 +538,8 @@ fn promote_program_to_bodyform(
 }
 
 fn match_i_op(candidate: Rc<BodyForm>) -> Option<(Rc<BodyForm>, Rc<BodyForm>, Rc<BodyForm>)> {
-    if let BodyForm::Call(_, cvec) = candidate.borrow() {
+    // Matches a primitve, no possibility of a tail item.
+    if let BodyForm::Call(_, cvec, None) = candidate.borrow() {
         if cvec.len() != 4 {
             return None;
         }
@@ -574,7 +582,7 @@ fn flatten_expression_to_names(expr: Rc<SExp>) -> Rc<BodyForm> {
         0,
         Rc::new(BodyForm::Value(SExp::Atom(expr.loc(), vec![b'+']))),
     );
-    Rc::new(BodyForm::Call(expr.loc(), call_vec))
+    Rc::new(BodyForm::Call(expr.loc(), call_vec, None))
 }
 
 impl<'info> Evaluator {
@@ -664,40 +672,37 @@ impl<'info> Evaluator {
         &self,
         allocator: &mut Allocator,
         visited: &mut VisitedMarker<'info, VisitedInfo>,
-        l: Srcloc,
-        call_name: &[u8],
-        parts: &[Rc<BodyForm>],
-        body: Rc<BodyForm>,
+        call: &CallSpec,
         prog_args: Rc<SExp>,
         arguments_to_convert: &[Rc<BodyForm>],
         env: &HashMap<Vec<u8>, Rc<BodyForm>>,
         only_inline: bool,
     ) -> Result<Rc<BodyForm>, CompileErr> {
         let mut all_primitive = true;
-        let mut target_vec: Vec<Rc<BodyForm>> = parts.to_owned();
+        let mut target_vec: Vec<Rc<BodyForm>> = call.args.to_owned();
 
-        if call_name == "@".as_bytes() {
+        if call.name == "@".as_bytes() {
             // Synthesize the environment for this function
             Ok(Rc::new(BodyForm::Quoted(SExp::Cons(
-                l.clone(),
-                Rc::new(SExp::Nil(l)),
+                call.loc.clone(),
+                Rc::new(SExp::Nil(call.loc.clone())),
                 prog_args,
             ))))
-        } else if call_name == "com".as_bytes() {
+        } else if call.name == "com".as_bytes() {
             let mut end_of_list = Rc::new(SExp::Cons(
-                l.clone(),
+                call.loc.clone(),
                 arguments_to_convert[0].to_sexp(),
-                Rc::new(SExp::Nil(l.clone())),
+                Rc::new(SExp::Nil(call.loc.clone())),
             ));
 
             for h in self.helpers.iter() {
-                end_of_list = Rc::new(SExp::Cons(l.clone(), h.to_sexp(), end_of_list))
+                end_of_list = Rc::new(SExp::Cons(call.loc.clone(), h.to_sexp(), end_of_list))
             }
 
             let use_body = SExp::Cons(
-                l.clone(),
-                Rc::new(SExp::Atom(l.clone(), "mod".as_bytes().to_vec())),
-                Rc::new(SExp::Cons(l, prog_args, end_of_list)),
+                call.loc.clone(),
+                Rc::new(SExp::Atom(call.loc.clone(), "mod".as_bytes().to_vec())),
+                Rc::new(SExp::Cons(call.loc.clone(), prog_args, end_of_list)),
             );
 
             let compiled = self.compile_code(allocator, false, Rc::new(use_body))?;
@@ -705,10 +710,10 @@ impl<'info> Evaluator {
             Ok(Rc::new(BodyForm::Quoted(compiled_borrowed.clone())))
         } else {
             let pres = self
-                .lookup_prim(l.clone(), call_name)
+                .lookup_prim(call.loc.clone(), &call.name)
                 .map(|prim| {
                     // Reduce all arguments.
-                    let mut converted_args = SExp::Nil(l.clone());
+                    let mut converted_args = SExp::Nil(call.loc.clone());
 
                     for i_reverse in 0..arguments_to_convert.len() {
                         let i = arguments_to_convert.len() - i_reverse - 1;
@@ -728,27 +733,28 @@ impl<'info> Evaluator {
                         }
 
                         converted_args =
-                            SExp::Cons(l.clone(), shrunk.to_sexp(), Rc::new(converted_args));
+                            SExp::Cons(call.loc.clone(), shrunk.to_sexp(), Rc::new(converted_args));
                     }
 
                     if all_primitive {
                         match self.run_prim(
                             allocator,
-                            l.clone(),
-                            make_prim_call(l.clone(), prim, Rc::new(converted_args)),
-                            Rc::new(SExp::Nil(l.clone())),
+                            call.loc.clone(),
+                            make_prim_call(call.loc.clone(), prim, Rc::new(converted_args)),
+                            Rc::new(SExp::Nil(call.loc.clone())),
                         ) {
                             Ok(res) => Ok(res),
                             Err(e) => {
                                 if only_inline || self.ignore_exn {
-                                    Ok(Rc::new(BodyForm::Call(l.clone(), target_vec.clone())))
+                                    Ok(Rc::new(BodyForm::Call(call.loc.clone(), target_vec.clone(), None)))
                                 } else {
                                     Err(e)
                                 }
                             }
                         }
                     } else {
-                        let reformed = BodyForm::Call(l.clone(), target_vec.clone());
+                        // Since this is a primitive, there's no tail transform.
+                        let reformed = BodyForm::Call(call.loc.clone(), target_vec.clone(), call.tail.clone());
                         self.chase_apply(allocator, visited, Rc::new(reformed))
                     }
                 })
@@ -757,11 +763,11 @@ impl<'info> Evaluator {
                     // return the unevaluated chunk with minimized
                     // arguments.
                     Err(CompileErr(
-                        l.clone(),
+                        call.loc.clone(),
                         format!(
                             "Don't yet support this call type {} {:?}",
-                            body.to_sexp(),
-                            body
+                            call.original.to_sexp(),
+                            call.original
                         ),
                     ))
                 })?;
@@ -814,6 +820,7 @@ impl<'info> Evaluator {
                 Rc::new(BodyForm::Call(
                     maybe_condition.loc(),
                     vec![x_head.clone(), cond.clone()],
+                    None,
                 )),
             );
 
@@ -823,6 +830,7 @@ impl<'info> Evaluator {
                 Rc::new(BodyForm::Call(
                     iftrue.loc(),
                     vec![apply_head.clone(), iftrue.clone(), env.clone()],
+                    None,
                 )),
             );
 
@@ -832,6 +840,7 @@ impl<'info> Evaluator {
                 Rc::new(BodyForm::Call(
                     iffalse.loc(),
                     vec![apply_head, iffalse.clone(), env],
+                    None,
                 )),
             );
 
@@ -847,6 +856,7 @@ impl<'info> Evaluator {
                     flatten_expression_to_names(surrogate_apply_true?.to_sexp()),
                     flatten_expression_to_names(surrogate_apply_false?.to_sexp()),
                 ],
+                None,
             ));
 
             return Ok(res);
@@ -861,7 +871,7 @@ impl<'info> Evaluator {
         visited: &'_ mut VisitedMarker<'info, VisitedInfo>,
         body: Rc<BodyForm>,
     ) -> Result<Rc<BodyForm>, CompileErr> {
-        if let BodyForm::Call(l, vec) = body.borrow() {
+        if let BodyForm::Call(l, vec, None) = body.borrow() {
             if is_apply_atom(vec[0].to_sexp()) {
                 if let Ok(run_program) = dequote(l.clone(), vec[1].clone()) {
                     return self.continue_apply(allocator, visited, vec[2].clone(), run_program);
@@ -885,36 +895,39 @@ impl<'info> Evaluator {
         &self,
         allocator: &mut Allocator,
         visited: &'_ mut VisitedMarker<'info, VisitedInfo>,
-        l: Srcloc,
-        call_loc: Srcloc,
-        call_name: &[u8],
-        _head_expr: Rc<BodyForm>,
-        parts: &[Rc<BodyForm>],
-        body: Rc<BodyForm>,
+        call: &CallSpec,
         prog_args: Rc<SExp>,
         arguments_to_convert: &[Rc<BodyForm>],
         env: &HashMap<Vec<u8>, Rc<BodyForm>>,
         only_inline: bool,
     ) -> Result<Rc<BodyForm>, CompileErr> {
-        let helper = select_helper(&self.helpers, call_name);
+        let helper = select_helper(&self.helpers, &call.name);
         match helper {
-            Some(HelperForm::Defmacro(mac)) => self.invoke_macro_expansion(
-                allocator,
-                visited,
-                mac.loc.clone(),
-                call_loc,
-                mac.program,
-                prog_args,
-                arguments_to_convert,
-                env,
-            ),
+            Some(HelperForm::Defmacro(mac)) => {
+                if call.tail.is_some() {
+                    return Err(CompileErr(
+                        call.loc.clone(),
+                        "Macros cannot use runtime rest arguments".to_string(),
+                    ));
+                }
+                self.invoke_macro_expansion(
+                    allocator,
+                    visited,
+                    mac.loc.clone(),
+                    call.loc.clone(),
+                    mac.program,
+                    prog_args,
+                    arguments_to_convert,
+                    env,
+                )
+            }
             Some(HelperForm::Defun(inline, defun)) => {
                 if !inline && only_inline {
-                    return Ok(body);
+                    return Ok(call.original.clone());
                 }
 
                 let argument_captures_untranslated =
-                    build_argument_captures(&call_loc, arguments_to_convert, defun.args.clone())?;
+                    build_argument_captures(&call.loc.clone(), arguments_to_convert, call.tail.clone(), defun.args.clone())?;
 
                 let mut argument_captures = HashMap::new();
                 // Do this to protect against misalignment
@@ -945,10 +958,7 @@ impl<'info> Evaluator {
                 .invoke_primitive(
                     allocator,
                     visited,
-                    l,
-                    call_name,
-                    parts,
-                    body,
+                    call,
                     prog_args,
                     arguments_to_convert,
                     env,
@@ -1066,7 +1076,7 @@ impl<'info> Evaluator {
                 }
             }
             BodyForm::Value(v) => Ok(Rc::new(BodyForm::Quoted(v.clone()))),
-            BodyForm::Call(l, parts) => {
+            BodyForm::Call(l, parts, tail) => {
                 if parts.is_empty() {
                     return Err(CompileErr(
                         l.clone(),
@@ -1079,29 +1089,31 @@ impl<'info> Evaluator {
                     parts.iter().skip(1).cloned().collect();
 
                 match head_expr.borrow() {
-                    BodyForm::Value(SExp::Atom(call_loc, call_name)) => self.handle_invoke(
+                    BodyForm::Value(SExp::Atom(_call_loc, call_name)) => self.handle_invoke(
                         allocator,
                         &mut visited,
-                        l.clone(),
-                        call_loc.clone(),
-                        call_name,
-                        head_expr.clone(),
-                        parts,
-                        body.clone(),
+                        &CallSpec {
+                            loc: l.clone(),
+                            name: call_name,
+                            args: parts,
+                            original: body.clone(),
+                            tail: tail.clone(),
+                        },
                         prog_args,
                         &arguments_to_convert,
                         env,
                         only_inline,
                     ),
-                    BodyForm::Value(SExp::Integer(call_loc, call_int)) => self.handle_invoke(
+                    BodyForm::Value(SExp::Integer(_call_loc, call_int)) => self.handle_invoke(
                         allocator,
                         &mut visited,
-                        l.clone(),
-                        call_loc.clone(),
-                        &u8_from_number(call_int.clone()),
-                        head_expr.clone(),
-                        parts,
-                        body.clone(),
+                        &CallSpec {
+                            loc: l.clone(),
+                            name: &u8_from_number(call_int.clone()),
+                            args: parts,
+                            original: body.clone(),
+                            tail: None,
+                        },
                         prog_args,
                         &arguments_to_convert,
                         env,

--- a/src/compiler/frontend.rs
+++ b/src/compiler/frontend.rs
@@ -194,7 +194,7 @@ fn args_to_expression_list(
     body: Rc<SExp>,
 ) -> Result<ArgsAndTail, CompileErr> {
     if body.nilp() {
-        Ok(Default::default())
+        Ok(ArgsAndTail::default())
     } else {
         match body.borrow() {
             SExp::Cons(_l, first, rest) => {

--- a/src/compiler/frontend.rs
+++ b/src/compiler/frontend.rs
@@ -5,7 +5,7 @@ use std::rc::Rc;
 
 use crate::classic::clvm::__type_compatibility__::bi_one;
 use crate::compiler::comptypes::{
-    list_to_cons, Binding, BodyForm, CompileErr, CompileForm, CompilerOpts, ConstantKind,
+    list_to_cons, ArgsAndTail, Binding, BodyForm, CallSpec, CompileErr, CompileForm, CompilerOpts, ConstantKind,
     DefconstData, DefmacData, DefunData, HelperForm, IncludeDesc, LetData, LetFormKind, ModAccum,
 };
 use crate::compiler::preprocessor::preprocess;
@@ -55,11 +55,15 @@ fn collect_used_names_bodyform(body: &BodyForm) -> Vec<Vec<u8>> {
             }
             _ => Vec::new(),
         },
-        BodyForm::Call(_l, vs) => {
+        BodyForm::Call(_l, vs, tail) => {
             let mut result = Vec::new();
             for a in vs {
                 let mut argnames = collect_used_names_bodyform(a);
                 result.append(&mut argnames);
+            }
+            if let Some(t) = tail {
+                let mut tail_names = collect_used_names_bodyform(t);
+                result.append(&mut tail_names);
             }
             result
         }
@@ -173,7 +177,7 @@ fn qq_to_expression_list(
                     )),
                     Rc::new(f_qq),
                     Rc::new(r_qq)
-                )))
+                ), None))
             }
         }
         SExp::Nil(l) => Ok(BodyForm::Quoted(SExp::Nil(l.clone()))),
@@ -187,23 +191,50 @@ fn qq_to_expression_list(
 fn args_to_expression_list(
     opts: Rc<dyn CompilerOpts>,
     body: Rc<SExp>,
-) -> Result<Vec<Rc<BodyForm>>, CompileErr> {
+) -> Result<ArgsAndTail, CompileErr> {
     if body.nilp() {
-        Ok(vec![])
+        Ok(Default::default())
     } else {
         match body.borrow() {
             SExp::Cons(_l, first, rest) => {
+                if let SExp::Atom(_fl, fname) = first.borrow() {
+                    if fname == b"&rest" {
+                        // Rest is a list containing one item that becomes the
+                        // tail.
+                        let args_no_tail = args_to_expression_list(opts, rest.clone())?;
+
+                        if args_no_tail.tail.is_some() {
+                            return Err(CompileErr(
+                                rest.loc(),
+                                "only one use of &rest is allowed".to_string(),
+                            ));
+                        }
+
+                        if args_no_tail.args.len() != 1 {
+                            return Err(CompileErr(
+                                body.loc(),
+                                "&rest specified with bad tail".to_string(),
+                            ));
+                        }
+
+                        // Return a tail.
+                        return Ok(ArgsAndTail {
+                            args: vec![],
+                            tail: Some(args_no_tail.args[0].clone()),
+                        });
+                    }
+                }
                 let mut result_list = Vec::new();
                 let f_compiled = compile_bodyform(opts.clone(), first.clone())?;
                 result_list.push(Rc::new(f_compiled));
-                let mut args = args_to_expression_list(opts, rest.clone())?;
-                result_list.append(&mut args);
-                Ok(result_list)
+                let mut args_and_tail = args_to_expression_list(opts, rest.clone())?;
+                result_list.append(&mut args_and_tail.args);
+                Ok(ArgsAndTail {
+                    args: result_list,
+                    tail: args_and_tail.tail,
+                })
             }
-            _ => Err(CompileErr(
-                body.loc(),
-                "Bad arg list tail ".to_string() + &body.to_string(),
-            )),
+            _ => Err(CompileErr(body.loc(), format!("Bad arg list tail {body}"))),
         }
     }
 }
@@ -248,17 +279,17 @@ pub fn compile_bodyform(
     match body.borrow() {
         SExp::Cons(l, op, tail) => {
             let application = || {
-                args_to_expression_list(opts.clone(), tail.clone()).and_then(|args| {
+                args_to_expression_list(opts.clone(), tail.clone()).and_then(|atail| {
                     compile_bodyform(opts.clone(), op.clone()).map(|func| {
                         let mut result_call = vec![Rc::new(func)];
-                        let mut args_clone = args.to_vec();
-                        let ending = if args.is_empty() {
+                        let mut args_clone = atail.args.to_vec();
+                        let ending = if atail.args.is_empty() {
                             l.ending()
                         } else {
-                            args[args.len() - 1].loc().ending()
+                            atail.args[atail.args.len() - 1].loc().ending()
                         };
                         result_call.append(&mut args_clone);
-                        BodyForm::Call(l.ext(&ending), result_call)
+                        BodyForm::Call(l.ext(&ending), result_call, atail.tail)
                     })
                 })
             };

--- a/src/compiler/frontend.rs
+++ b/src/compiler/frontend.rs
@@ -5,8 +5,9 @@ use std::rc::Rc;
 
 use crate::classic::clvm::__type_compatibility__::bi_one;
 use crate::compiler::comptypes::{
-    list_to_cons, ArgsAndTail, Binding, BodyForm, CallSpec, CompileErr, CompileForm, CompilerOpts, ConstantKind,
-    DefconstData, DefmacData, DefunData, HelperForm, IncludeDesc, LetData, LetFormKind, ModAccum,
+    list_to_cons, ArgsAndTail, Binding, BodyForm, CompileErr, CompileForm, CompilerOpts,
+    ConstantKind, DefconstData, DefmacData, DefunData, HelperForm, IncludeDesc, LetData,
+    LetFormKind, ModAccum,
 };
 use crate::compiler::preprocessor::preprocess;
 use crate::compiler::rename::rename_children_compileform;

--- a/src/compiler/frontend.rs
+++ b/src/compiler/frontend.rs
@@ -202,6 +202,11 @@ fn args_to_expression_list(
                     if fname == b"&rest" {
                         // Rest is a list containing one item that becomes the
                         // tail.
+                        //
+                        // Downstream, we'll use the tail instead of a nil as the
+                        // final element of a call form.  In the inline case, this
+                        // means that argument references will be generated into
+                        // the runtime tail expression when appropriate.
                         let args_no_tail = args_to_expression_list(opts, rest.clone())?;
 
                         if args_no_tail.tail.is_some() {
@@ -284,6 +289,9 @@ pub fn compile_bodyform(
                     compile_bodyform(opts.clone(), op.clone()).map(|func| {
                         let mut result_call = vec![Rc::new(func)];
                         let mut args_clone = atail.args.to_vec();
+                        // Ensure that the full extent of the call expression
+                        // in the source file becomes the Srcloc given to the
+                        // call itself.
                         let ending = if atail.args.is_empty() {
                             l.ending()
                         } else {

--- a/src/compiler/inline.rs
+++ b/src/compiler/inline.rs
@@ -11,7 +11,8 @@ use crate::classic::clvm_tools::stages::stage_0::TRunProgram;
 use crate::compiler::codegen::{generate_expr_code, get_call_name, get_callable};
 use crate::compiler::compiler::is_at_capture;
 use crate::compiler::comptypes::{
-    ArgsAndTail, BodyForm, Callable, CallSpec, CompileErr, CompiledCode, CompilerOpts, InlineFunction, PrimaryCodegen,
+    ArgsAndTail, BodyForm, CallSpec, Callable, CompileErr, CompiledCode, CompilerOpts,
+    InlineFunction, PrimaryCodegen,
 };
 use crate::compiler::sexp::{decode_string, SExp};
 use crate::compiler::srcloc::Srcloc;
@@ -414,7 +415,7 @@ fn replace_inline_body(
             }
         }
         BodyForm::Value(SExp::Atom(_, a)) => {
-            let alookup = arg_lookup(callsite, inline.args.clone(), args, tail.clone(), a.clone())?
+            let alookup = arg_lookup(callsite, inline.args.clone(), args, tail, a.clone())?
                 .unwrap_or_else(|| expr.clone());
             Ok(alookup)
         }

--- a/src/compiler/inline.rs
+++ b/src/compiler/inline.rs
@@ -11,7 +11,7 @@ use crate::classic::clvm_tools::stages::stage_0::TRunProgram;
 use crate::compiler::codegen::{generate_expr_code, get_call_name, get_callable};
 use crate::compiler::compiler::is_at_capture;
 use crate::compiler::comptypes::{
-    BodyForm, Callable, CompileErr, CompiledCode, CompilerOpts, InlineFunction, PrimaryCodegen,
+    ArgsAndTail, BodyForm, Callable, CallSpec, CompileErr, CompiledCode, CompilerOpts, InlineFunction, PrimaryCodegen,
 };
 use crate::compiler::sexp::{decode_string, SExp};
 use crate::compiler::srcloc::Srcloc;
@@ -25,6 +25,8 @@ fn apply_fn(loc: Srcloc, name: String, expr: Rc<BodyForm>) -> Rc<BodyForm> {
             Rc::new(BodyForm::Value(SExp::atom_from_string(loc, &name))),
             expr,
         ],
+        // Ok: applying a primitive or builtin requires no tail.
+        None,
     ))
 }
 
@@ -36,40 +38,57 @@ fn at_form(loc: Srcloc, path: Number) -> Rc<BodyForm> {
     )
 }
 
-pub fn synthesize_args(arg_: Rc<SExp>) -> Vec<Rc<BodyForm>> {
+/// Generates a list of paths that correspond to the toplevel positions in arg_
+/// and if given, the improper tail.
+pub fn synthesize_args(arg_: Rc<SExp>) -> (Vec<Rc<BodyForm>>, Option<Rc<BodyForm>>) {
+    let two = 2_i32.to_bigint().unwrap();
     let mut start = 5_i32.to_bigint().unwrap();
+    let mut tail = bi_one();
     let mut result = Vec::new();
     let mut arg = arg_;
     loop {
         match arg.borrow() {
             SExp::Cons(l, _, b) => {
                 result.push(at_form(l.clone(), start.clone()));
-                start = bi_one() + start.clone() * 2_i32.to_bigint().unwrap();
+                tail = bi_one() | (two.clone() * tail);
+                start = bi_one() + start.clone() * two.clone();
                 arg = b.clone();
             }
+            SExp::Atom(l, _) => {
+                return (result, Some(at_form(l.clone(), tail)));
+            }
             _ => {
-                return result;
+                return (result, None);
             }
         }
     }
 }
 
-fn enlist_remaining_args(loc: Srcloc, arg_choice: usize, args: &[Rc<BodyForm>]) -> Rc<BodyForm> {
-    let mut result_body = BodyForm::Value(SExp::Nil(loc.clone()));
+fn enlist_remaining_args(
+    loc: Srcloc,
+    arg_choice: usize,
+    args: &[Rc<BodyForm>],
+    tail: Option<Rc<BodyForm>>,
+) -> Rc<BodyForm> {
+    let mut result_body = tail.unwrap_or_else(|| Rc::new(BodyForm::Value(SExp::Nil(loc.clone()))));
 
-    for i_reverse in arg_choice..args.len() {
-        let i = args.len() - i_reverse - 1;
-        result_body = BodyForm::Call(
+    for arg in args.iter().skip(arg_choice).rev() {
+        result_body = Rc::new(BodyForm::Call(
             loc.clone(),
             vec![
-                Rc::new(BodyForm::Value(SExp::atom_from_string(loc.clone(), "c"))),
-                args[i].clone(),
-                Rc::new(result_body),
+                Rc::new(BodyForm::Value(SExp::Integer(
+                    loc.clone(),
+                    4_u32.to_bigint().unwrap(),
+                ))),
+                arg.clone(),
+                result_body,
             ],
-        );
+            // Ok: applying cons.
+            None,
+        ));
     }
 
-    Rc::new(result_body)
+    result_body
 }
 
 fn pick_value_from_arg_element(
@@ -117,38 +136,95 @@ fn pick_value_from_arg_element(
     }
 }
 
+fn choose_arg_from_list_or_tail(
+    callsite: &Srcloc,
+    args: &[Rc<BodyForm>],
+    tail: Option<Rc<BodyForm>>,
+    index: usize,
+) -> Result<Rc<BodyForm>, CompileErr> {
+    let two = 2_i32.to_bigint().unwrap();
+
+    if index >= args.len() {
+        if let Some(t) = tail {
+            let target_shift = index - args.len();
+            let target_path =
+                (two.clone() << target_shift) | (((two << target_shift) - bi_one()) >> 2);
+            return Ok(Rc::new(BodyForm::Call(
+                callsite.clone(),
+                vec![
+                    Rc::new(BodyForm::Value(SExp::Integer(
+                        t.loc(),
+                        2_u32.to_bigint().unwrap(),
+                    ))),
+                    Rc::new(BodyForm::Value(SExp::Integer(t.loc(), target_path))),
+                    t.clone(),
+                ],
+                // Applying a primitive.
+                None,
+            )));
+        }
+
+        return Err(CompileErr(
+            callsite.clone(),
+            format!("Lookup for argument {} that wasn't passed", index + 1),
+        ));
+    }
+
+    Ok(args[index].clone())
+}
+
 fn arg_lookup(
     callsite: Srcloc,
-    match_args: Rc<SExp>,
-    arg_choice: usize,
+    mut match_args: Rc<SExp>,
     args: &[Rc<BodyForm>],
+    mut tail: Option<Rc<BodyForm>>,
     name: Vec<u8>,
 ) -> Result<Option<Rc<BodyForm>>, CompileErr> {
-    match match_args.borrow() {
-        SExp::Cons(_l, f, r) => {
-            if arg_choice >= args.len() {
-                return Err(CompileErr(
-                    callsite,
-                    format!("Lookup for argument {} that wasn't passed", arg_choice + 1),
+    let two = 2_i32.to_bigint().unwrap();
+    let mut arg_choice = 0;
+
+    loop {
+        match match_args.borrow() {
+            SExp::Cons(_l, f, r) => {
+                if let Some(x) = pick_value_from_arg_element(
+                    f.clone(),
+                    choose_arg_from_list_or_tail(&callsite, args, tail.clone(), arg_choice)?,
+                    &|x| x,
+                    name.clone(),
+                ) {
+                    return Ok(Some(x));
+                } else {
+                    arg_choice += 1;
+                    match_args = r.clone();
+                    continue;
+                }
+            }
+            _ => {
+                if arg_choice > args.len() {
+                    let underflow = arg_choice - args.len();
+                    let tail_path = (two.clone() << underflow) - bi_one();
+                    tail = tail.map(|t| {
+                        Rc::new(BodyForm::Call(
+                            t.loc(),
+                            vec![
+                                Rc::new(BodyForm::Value(SExp::Integer(t.loc(), two.clone()))),
+                                Rc::new(BodyForm::Value(SExp::Integer(t.loc(), tail_path))),
+                                t.clone(),
+                            ],
+                            None,
+                        ))
+                    });
+                }
+
+                let tail_list = enlist_remaining_args(match_args.loc(), arg_choice, args, tail);
+                return Ok(pick_value_from_arg_element(
+                    match_args.clone(),
+                    tail_list,
+                    &|x: Rc<BodyForm>| x,
+                    name,
                 ));
             }
-
-            match pick_value_from_arg_element(
-                f.clone(),
-                args[arg_choice].clone(),
-                &|x| x,
-                name.clone(),
-            ) {
-                Some(x) => Ok(Some(x)),
-                None => arg_lookup(callsite, r.clone(), arg_choice + 1, args, name),
-            }
         }
-        _ => Ok(pick_value_from_arg_element(
-            match_args.clone(),
-            enlist_remaining_args(match_args.loc(), arg_choice, args),
-            &|x: Rc<BodyForm>| x,
-            name,
-        )),
     }
 }
 
@@ -163,6 +239,71 @@ fn get_inline_callable(
     get_callable(opts, compiler, loc, name)
 }
 
+fn make_args_for_call_from_inline(
+    visited_inlines: &mut HashSet<Vec<u8>>,
+    runner: Rc<dyn TRunProgram>,
+    opts: Rc<dyn CompilerOpts>,
+    compiler: &PrimaryCodegen,
+    inline: &InlineFunction,
+    incoming_spec: &CallSpec,
+    call_spec: &CallSpec,
+) -> Result<ArgsAndTail, CompileErr> {
+    if call_spec.args.is_empty() {
+        // This is a nil.
+        return Ok(ArgsAndTail {
+            args: vec![],
+            tail: call_spec.tail.clone(),
+        });
+    }
+
+    let mut new_args = Vec::new();
+
+    for (i, arg) in call_spec.args.iter().enumerate() {
+        if i == 0 {
+            new_args.push(arg.clone());
+            continue;
+        }
+
+        let mut new_visited = visited_inlines.clone();
+        let replaced = replace_inline_body(
+            &mut new_visited,
+            runner.clone(),
+            opts.clone(),
+            compiler,
+            arg.loc(),
+            inline,
+            incoming_spec.args,
+            incoming_spec.tail.clone(),
+            call_spec.loc.clone(),
+            arg.clone(),
+        )?;
+        new_args.push(replaced);
+    }
+
+    let mut new_visited = visited_inlines.clone();
+    let replaced_tail = if let Some(t) = call_spec.tail.as_ref() {
+        Some(replace_inline_body(
+            &mut new_visited,
+            runner,
+            opts,
+            compiler,
+            t.loc(),
+            inline,
+            incoming_spec.args,
+            incoming_spec.tail.clone(),
+            call_spec.loc.clone(),
+            t.clone(),
+        )?)
+    } else {
+        None
+    };
+
+    Ok(ArgsAndTail {
+        args: new_args,
+        tail: replaced_tail,
+    })
+}
+
 #[allow(clippy::too_many_arguments)]
 fn replace_inline_body(
     visited_inlines: &mut HashSet<Vec<u8>>,
@@ -172,6 +313,7 @@ fn replace_inline_body(
     loc: Srcloc,
     inline: &InlineFunction,
     args: &[Rc<BodyForm>],
+    tail: Option<Rc<BodyForm>>,
     callsite: Srcloc,
     expr: Rc<BodyForm>,
 ) -> Result<Rc<BodyForm>, CompileErr> {
@@ -180,8 +322,7 @@ fn replace_inline_body(
             loc,
             "let binding should have been hoisted before optimization".to_string(),
         )),
-        BodyForm::Call(l, call_args) => {
-            let mut new_args = Vec::new();
+        BodyForm::Call(l, call_args, call_tail) => {
             // Ensure that we don't count branched invocations when checking
             // each call downstream of the main expr is recursive.
             //
@@ -204,25 +345,29 @@ fn replace_inline_body(
             // We ensure here that each argument has a separate visited stack.
             // Recursion only happens when the same stack encounters an inline
             // twice.
-            for (i, arg) in call_args.iter().enumerate() {
-                if i == 0 {
-                    new_args.push(arg.clone());
-                } else {
-                    let mut new_visited = visited_inlines.clone();
-                    let replaced = replace_inline_body(
-                        &mut new_visited,
-                        runner.clone(),
-                        opts.clone(),
-                        compiler,
-                        arg.loc(),
-                        inline,
-                        args,
-                        callsite.clone(),
-                        arg.clone(),
-                    )?;
-                    new_args.push(replaced);
-                }
-            }
+            //
+            let args_and_tail = make_args_for_call_from_inline(
+                visited_inlines,
+                runner.clone(),
+                opts.clone(),
+                compiler,
+                inline,
+                &CallSpec {
+                    loc: callsite.clone(),
+                    name: &inline.name,
+                    args,
+                    tail,
+                    original: expr.clone(),
+                },
+                &CallSpec {
+                    loc: callsite.clone(),
+                    name: &inline.name,
+                    args: call_args,
+                    tail: call_tail.clone(),
+                    original: expr.clone(),
+                },
+            )?;
+
             // If the called function is an inline, we'll expand it here.
             // This is so we can preserve the context of argument expressions
             // so no new mapping is needed.  This solves a number of problems
@@ -230,6 +375,8 @@ fn replace_inline_body(
             //
             // If it's a macro we'll expand it here so we can recurse and
             // determine whether an inline is the next level.
+            //
+            // It's an inline, so we need to fulfill its arguments.
             match get_inline_callable(opts.clone(), compiler, l.clone(), call_args[0].clone())? {
                 Callable::CallInline(l, new_inline) => {
                     if visited_inlines.contains(&new_inline.name) {
@@ -245,7 +392,7 @@ fn replace_inline_body(
                     visited_inlines.insert(new_inline.name.clone());
 
                     let pass_on_args: Vec<Rc<BodyForm>> =
-                        new_args.iter().skip(1).cloned().collect();
+                        args_and_tail.args.iter().skip(1).cloned().collect();
                     replace_inline_body(
                         visited_inlines,
                         runner,
@@ -254,18 +401,20 @@ fn replace_inline_body(
                         l, // clippy update since 1.59
                         &new_inline,
                         &pass_on_args,
+                        args_and_tail.tail,
                         callsite,
                         new_inline.body.clone(),
                     )
                 }
                 _ => {
-                    let call = BodyForm::Call(l.clone(), new_args);
+                    // Tail passes through to a normal call form.
+                    let call = BodyForm::Call(l.clone(), args_and_tail.args, args_and_tail.tail);
                     Ok(Rc::new(call))
                 }
             }
         }
         BodyForm::Value(SExp::Atom(_, a)) => {
-            let alookup = arg_lookup(callsite, inline.args.clone(), 0, args, a.clone())?
+            let alookup = arg_lookup(callsite, inline.args.clone(), args, tail.clone(), a.clone())?
                 .unwrap_or_else(|| expr.clone());
             Ok(alookup)
         }
@@ -279,6 +428,16 @@ fn replace_inline_body(
 ///
 /// This will probably be changed at some point to return Rc<BodyForm> so it
 /// can be treated as a desugaring step that's subject to frontend optimization.
+///
+/// There are two cases when we have rest arguments:
+///
+/// 1) Too few arguments are provided along with a rest argument.
+///    In this case, we can't tell what's been provided for the variable arguments
+///    so we synthesize paths into the rest argument and hope for the best.
+///
+/// 2) Too many arguments are provided (optionally with a rest argument).
+///    In this case, we collect the following arguments and pass them to a
+///    tail argument if one exists.  If not, then they're discarded.
 #[allow(clippy::too_many_arguments)]
 pub fn replace_in_inline(
     allocator: &mut Allocator,
@@ -289,6 +448,7 @@ pub fn replace_in_inline(
     inline: &InlineFunction,
     callsite: Srcloc,
     args: &[Rc<BodyForm>],
+    tail: Option<Rc<BodyForm>>,
 ) -> Result<CompiledCode, CompileErr> {
     let mut visited = HashSet::new();
     visited.insert(inline.name.clone());
@@ -300,6 +460,7 @@ pub fn replace_in_inline(
         loc,
         inline,
         args,
+        tail,
         callsite,
         inline.body.clone(),
     )

--- a/src/compiler/optimize.rs
+++ b/src/compiler/optimize.rs
@@ -115,7 +115,7 @@ pub fn optimize_expr(
                 _ => None,
             }
         }
-        BodyForm::Call(l, forms, Some(_)) => None,
+        BodyForm::Call(_l, _forms, Some(_)) => None,
         BodyForm::Value(SExp::Integer(l, i)) => Some((
             true,
             Rc::new(BodyForm::Quoted(SExp::Integer(l.clone(), i.clone()))),

--- a/src/compiler/optimize.rs
+++ b/src/compiler/optimize.rs
@@ -31,7 +31,7 @@ pub fn optimize_expr(
 ) -> Option<(bool, Rc<BodyForm>)> {
     match body.borrow() {
         BodyForm::Quoted(_) => Some((true, body)),
-        BodyForm::Call(l, forms) => {
+        BodyForm::Call(l, forms, None) => {
             // () evaluates to ()
             if forms.is_empty() {
                 return Some((true, body));
@@ -80,7 +80,8 @@ pub fn optimize_expr(
                         let mut replaced_args =
                             optimized_args.iter().map(|x| x.1.clone()).collect();
                         result_list.append(&mut replaced_args);
-                        let code = BodyForm::Call(l.clone(), result_list);
+                        // Calling a primitive.
+                        let code = BodyForm::Call(l.clone(), result_list, None);
 
                         if constant {
                             run(
@@ -114,6 +115,7 @@ pub fn optimize_expr(
                 _ => None,
             }
         }
+        BodyForm::Call(l, forms, Some(_)) => None,
         BodyForm::Value(SExp::Integer(l, i)) => Some((
             true,
             Rc::new(BodyForm::Quoted(SExp::Integer(l.clone(), i.clone()))),

--- a/src/compiler/rename.rs
+++ b/src/compiler/rename.rs
@@ -161,12 +161,15 @@ fn rename_in_bodyform(namemap: &HashMap<Vec<u8>, Vec<u8>>, b: Rc<BodyForm>) -> B
             _ => BodyForm::Value(atom.clone()),
         },
 
-        BodyForm::Call(l, vs) => {
+        BodyForm::Call(l, vs, tail) => {
             let new_vs = vs
                 .iter()
                 .map(|x| Rc::new(rename_in_bodyform(namemap, x.clone())))
                 .collect();
-            BodyForm::Call(l.clone(), new_vs)
+            let new_tail = tail
+                .as_ref()
+                .map(|t| Rc::new(rename_in_bodyform(namemap, t.clone())));
+            BodyForm::Call(l.clone(), new_vs, new_tail)
         }
 
         BodyForm::Mod(l, prog) => BodyForm::Mod(l.clone(), prog.clone()),
@@ -249,12 +252,15 @@ fn rename_args_bodyform(b: &BodyForm) -> BodyForm {
         BodyForm::Quoted(e) => BodyForm::Quoted(e.clone()),
         BodyForm::Value(v) => BodyForm::Value(v.clone()),
 
-        BodyForm::Call(l, vs) => {
+        BodyForm::Call(l, vs, tail) => {
             let new_vs = vs
                 .iter()
                 .map(|a| Rc::new(rename_args_bodyform(a)))
                 .collect();
-            BodyForm::Call(l.clone(), new_vs)
+            let new_tail = tail
+                .as_ref()
+                .map(|t| Rc::new(rename_args_bodyform(t.borrow())));
+            BodyForm::Call(l.clone(), new_vs, new_tail)
         }
         BodyForm::Mod(l, program) => BodyForm::Mod(l.clone(), program.clone()),
     }

--- a/src/tests/compiler/compiler.rs
+++ b/src/tests/compiler/compiler.rs
@@ -1210,7 +1210,7 @@ fn test_inline_in_assign_not_actually_recursive() {
 fn test_simple_rest_call_0() {
     let prog = indoc! {"
 (mod X
-  (include *standard-cl-23*)
+  (include *standard-cl-21*)
 
   (defun F Xs
     (if Xs
@@ -1230,7 +1230,7 @@ fn test_simple_rest_call_0() {
 fn test_simple_rest_call_inline() {
     let prog = indoc! {"
 (mod X
-  (include *standard-cl-23*)
+  (include *standard-cl-21*)
 
   (defun sum (Xs)
     (if Xs

--- a/src/tests/compiler/compiler.rs
+++ b/src/tests/compiler/compiler.rs
@@ -58,7 +58,7 @@ fn run_string_maybe_opt(
     })
 }
 
-fn run_string(content: &String, args: &String) -> Result<Rc<SExp>, CompileErr> {
+pub fn run_string(content: &String, args: &String) -> Result<Rc<SExp>, CompileErr> {
     run_string_maybe_opt(content, args, false)
 }
 
@@ -1204,4 +1204,46 @@ fn test_inline_in_assign_not_actually_recursive() {
     .to_string();
     let res = run_string(&prog, &"()".to_string()).expect("should compile and run");
     assert_eq!(res.to_string(), "9999");
+}
+
+#[test]
+fn test_simple_rest_call_0() {
+    let prog = indoc! {"
+(mod X
+  (include *standard-cl-23*)
+
+  (defun F Xs
+    (if Xs
+      (+ (f Xs) (F &rest (r Xs)))
+      ()
+      )
+    )
+
+  (F &rest X)
+  )"}
+    .to_string();
+    let res = run_string(&prog, &"(13 99 144)".to_string()).expect("should compile and run");
+    assert_eq!(res.to_string(), "256");
+}
+
+#[test]
+fn test_simple_rest_call_inline() {
+    let prog = indoc! {"
+(mod X
+  (include *standard-cl-23*)
+
+  (defun sum (Xs)
+    (if Xs
+      (+ (f Xs) (sum (r Xs)))
+      ()
+      )
+    )
+
+  (defun-inline F (A1 . A2) (* A1 (sum A2)))
+
+  (F 3 &rest X)
+  )"}
+    .to_string();
+    let res = run_string(&prog, &"(13 99 144)".to_string()).expect("should compile and run");
+    assert_eq!(res.to_string(), "768");
 }

--- a/src/tests/compiler/mod.rs
+++ b/src/tests/compiler/mod.rs
@@ -9,6 +9,7 @@ mod clvm;
 mod compiler;
 mod evaluate;
 mod repl;
+mod restargs;
 mod runtypes;
 mod srcloc;
 mod usecheck;

--- a/src/tests/compiler/repl.rs
+++ b/src/tests/compiler/repl.rs
@@ -31,7 +31,7 @@ where
     res.map(|r| r.map(|r| r.to_sexp().to_string()))
 }
 
-fn test_repl_outcome<S>(inputs: Vec<S>) -> Result<Option<String>, CompileErr>
+pub fn test_repl_outcome<S>(inputs: Vec<S>) -> Result<Option<String>, CompileErr>
 where
     S: ToString,
 {

--- a/src/tests/compiler/restargs.rs
+++ b/src/tests/compiler/restargs.rs
@@ -896,8 +896,55 @@ fn test_repl_10() {
             "(defun F (A B C) (list A B C))",
             "(F 5 7 &rest (list 101 103))"
         ])
-        .unwrap()
-        .unwrap(),
+            .unwrap()
+            .unwrap(),
         "(q 5 7 101)"
+    );
+}
+
+#[test]
+fn test_compiler_tail_let_inline() {
+    let prog = indoc! {"
+(mod (X Y)
+  (include *standard-cl-21*)
+
+  (defun F (A B C) (list A B C))
+
+  (defun-inline G (X Y) (F X &rest (let ((Q (+ Y 1))) (list Y Q))))
+
+  (G X Y)
+  )"}
+    .to_string();
+    let res = run_string(&prog, &"(5 7)".to_string()).expect("should compile and run");
+    assert_eq!(res.to_string(), "(5 7 8)");
+}
+
+#[test]
+fn test_compiler_tail_let_ni() {
+    let prog = indoc! {"
+(mod (X Y)
+  (include *standard-cl-21*)
+
+  (defun F (A B C) (list A B C))
+
+  (defun G (X Y) (F X &rest (let ((Q (+ Y 1))) (list Y Q))))
+
+  (G X Y)
+  )"}
+    .to_string();
+    let res = run_string(&prog, &"(5 7)".to_string()).expect("should compile and run");
+    assert_eq!(res.to_string(), "(5 7 8)");
+}
+
+#[test]
+fn test_repl_tail_let() {
+    assert_eq!(
+        test_repl_outcome(vec![
+            "(defun F (A B C D) (list A B C D))",
+            "(F 5 7 &rest (let ((Q (list 101 103))) (c 99 Q)))"
+        ])
+            .unwrap()
+            .unwrap(),
+        "(q 5 7 99 101)"
     );
 }

--- a/src/tests/compiler/restargs.rs
+++ b/src/tests/compiler/restargs.rs
@@ -52,7 +52,7 @@ use crate::tests::compiler::repl::test_repl_outcome;
 fn test_simple_inline_toomany_args_01() {
     let prog = indoc! {"
 (mod (X Y Z)
-  (include *standard-cl-23*)
+  (include *standard-cl-21*)
 
   (defun-inline F (A B) (+ A B))
 
@@ -67,7 +67,7 @@ fn test_simple_inline_toomany_args_01() {
 fn test_simple_inline_toomany_args_improper_tail_02() {
     let prog = indoc! {"
 (mod (X Y Z)
-  (include *standard-cl-23*)
+  (include *standard-cl-21*)
 
   (defun sum (Xs)
     (if Xs
@@ -89,7 +89,7 @@ fn test_simple_inline_toomany_args_improper_tail_02() {
 fn test_simple_inline_toomany_args_improper_no_tail_03() {
     let prog = indoc! {"
 (mod (X Y)
-  (include *standard-cl-23*)
+  (include *standard-cl-21*)
 
   (defun sum (Xs)
     (if Xs
@@ -111,7 +111,7 @@ fn test_simple_inline_toomany_args_improper_no_tail_03() {
 fn test_simple_inline_exact_no_tails_04() {
     let prog = indoc! {"
 (mod (X Y)
-  (include *standard-cl-23*)
+  (include *standard-cl-21*)
 
   (defun-inline F (A B) (* A B))
 
@@ -126,7 +126,7 @@ fn test_simple_inline_exact_no_tails_04() {
 fn test_simple_inline_exact_improper_tail_05() {
     let prog = indoc! {"
 (mod (X Y Z)
-  (include *standard-cl-23*)
+  (include *standard-cl-21*)
 
   (defun-inline F (A B . C) (* A B C))
 
@@ -141,7 +141,7 @@ fn test_simple_inline_exact_improper_tail_05() {
 fn test_simple_inline_exact_improper_no_tail_06() {
     let prog = indoc! {"
 (mod (X Y)
-  (include *standard-cl-23*)
+  (include *standard-cl-21*)
 
   (defun-inline F (A B . C) (+ A B C))
 
@@ -156,7 +156,7 @@ fn test_simple_inline_exact_improper_no_tail_06() {
 fn test_simple_inline_exact_toofew_improper_tail_07() {
     let prog = indoc! {"
 (mod (X Y Z)
-  (include *standard-cl-23*)
+  (include *standard-cl-21*)
 
   (defun-inline F (A B C . D) (list A B C (f D)))
 
@@ -171,7 +171,7 @@ fn test_simple_inline_exact_toofew_improper_tail_07() {
 fn test_simple_inline_exact_toofew_tail_08() {
     let prog = indoc! {"
 (mod (X Y Z)
-  (include *standard-cl-23*)
+  (include *standard-cl-21*)
 
   (defun-inline F (A B C) (list A B C))
 
@@ -186,7 +186,7 @@ fn test_simple_inline_exact_toofew_tail_08() {
 fn test_simple_inline_exact_toofew_improper_no_tail_09() {
     let prog = indoc! {"
 (mod (X Y)
-  (include *standard-cl-23*)
+  (include *standard-cl-21*)
 
   (defun-inline F (A B C . D) (list A B C (f D)))
 
@@ -205,7 +205,7 @@ fn test_simple_inline_exact_toofew_improper_no_tail_09() {
 fn test_simple_inline_exact_toofew_tail_10() {
     let prog = indoc! {"
 (mod (X Y Z)
-  (include *standard-cl-23*)
+  (include *standard-cl-21*)
 
   (defun-inline F (A B C) (list A B C))
 
@@ -220,7 +220,7 @@ fn test_simple_inline_exact_toofew_tail_10() {
 fn test_inline_inline_toomany_args_11() {
     let prog = indoc! {"
 (mod (X Y Z)
-  (include *standard-cl-23*)
+  (include *standard-cl-21*)
 
   (defun-inline F (A B) (+ A B))
 
@@ -237,7 +237,7 @@ fn test_inline_inline_toomany_args_11() {
 fn test_inline_inline_toomany_args_improper_tail_12() {
     let prog = indoc! {"
 (mod (X Y Z)
-  (include *standard-cl-23*)
+  (include *standard-cl-21*)
 
   (defun-inline return-list (Xs) Xs)
 
@@ -254,7 +254,7 @@ fn test_inline_inline_toomany_args_improper_tail_12() {
 fn test_simple_inline_toomany_args_improper_no_tail_13() {
     let prog = indoc! {"
 (mod (X Y)
-  (include *standard-cl-23*)
+  (include *standard-cl-21*)
 
   (defun-inline return-list (Xs) Xs)
 
@@ -271,7 +271,7 @@ fn test_simple_inline_toomany_args_improper_no_tail_13() {
 fn test_inline_inline_exact_no_tails_14() {
     let prog = indoc! {"
 (mod (X Y)
-  (include *standard-cl-23*)
+  (include *standard-cl-21*)
 
   (defun-inline F (A B) (* A B))
 
@@ -288,7 +288,7 @@ fn test_inline_inline_exact_no_tails_14() {
 fn test_inline_inline_exact_improper_tail_15() {
     let prog = indoc! {"
 (mod (X Y Z)
-  (include *standard-cl-23*)
+  (include *standard-cl-21*)
 
   (defun-inline F (A B . C) (* A B C))
 
@@ -305,7 +305,7 @@ fn test_inline_inline_exact_improper_tail_15() {
 fn test_inline_inline_exact_improper_no_tail_16() {
     let prog = indoc! {"
 (mod (X Y)
-  (include *standard-cl-23*)
+  (include *standard-cl-21*)
 
   (defun-inline F (A B . C) (+ A B C))
 
@@ -322,7 +322,7 @@ fn test_inline_inline_exact_improper_no_tail_16() {
 fn test_simple_inline_exact_toofew_improper_tail_17() {
     let prog = indoc! {"
 (mod (X Y Z)
-  (include *standard-cl-23*)
+  (include *standard-cl-21*)
 
   (defun-inline F (A B C . D) (list A B C (f D)))
 
@@ -339,7 +339,7 @@ fn test_simple_inline_exact_toofew_improper_tail_17() {
 fn test_inline_inline_exact_toofew_tail_18() {
     let prog = indoc! {"
 (mod (X Y Z)
-  (include *standard-cl-23*)
+  (include *standard-cl-21*)
 
   (defun-inline F (A B C) (list A B C))
 
@@ -356,7 +356,7 @@ fn test_inline_inline_exact_toofew_tail_18() {
 fn test_inline_inline_exact_toofew_improper_no_tail_19() {
     let prog = indoc! {"
 (mod (X Y)
-  (include *standard-cl-23*)
+  (include *standard-cl-21*)
 
   (defun-inline F (A B C . D) (list A B C (f D)))
 
@@ -377,7 +377,7 @@ fn test_inline_inline_exact_toofew_improper_no_tail_19() {
 fn test_simple_inline_exact_toofew_tail_20() {
     let prog = indoc! {"
 (mod (X Y Z)
-  (include *standard-cl-23*)
+  (include *standard-cl-21*)
 
   (defun-inline F (A B C) (list A B C))
 
@@ -394,7 +394,7 @@ fn test_simple_inline_exact_toofew_tail_20() {
 fn test_ni_ni_toomany_args_21() {
     let prog = indoc! {"
 (mod (X Y Z)
-  (include *standard-cl-23*)
+  (include *standard-cl-21*)
 
   (defun F (A B) (+ A B))
 
@@ -411,7 +411,7 @@ fn test_ni_ni_toomany_args_21() {
 fn test_ni_ni_toomany_args_improper_tail_22() {
     let prog = indoc! {"
 (mod (X Y Z)
-  (include *standard-cl-23*)
+  (include *standard-cl-21*)
 
   (defun return-list (Xs) Xs)
 
@@ -428,7 +428,7 @@ fn test_ni_ni_toomany_args_improper_tail_22() {
 fn test_simple_inline_toomany_args_improper_no_tail_23() {
     let prog = indoc! {"
 (mod (X Y)
-  (include *standard-cl-23*)
+  (include *standard-cl-21*)
 
   (defun return-list (Xs) Xs)
 
@@ -445,7 +445,7 @@ fn test_simple_inline_toomany_args_improper_no_tail_23() {
 fn test_ni_ni_exact_no_tails_24() {
     let prog = indoc! {"
 (mod (X Y)
-  (include *standard-cl-23*)
+  (include *standard-cl-21*)
 
   (defun F (A B) (* A B))
 
@@ -462,7 +462,7 @@ fn test_ni_ni_exact_no_tails_24() {
 fn test_ni_ni_exact_improper_tail_25() {
     let prog = indoc! {"
 (mod (X Y Z)
-  (include *standard-cl-23*)
+  (include *standard-cl-21*)
 
   (defun F (A B . C) (* A B C))
 
@@ -479,7 +479,7 @@ fn test_ni_ni_exact_improper_tail_25() {
 fn test_ni_ni_rest_call_25() {
     let prog = indoc! {"
 (mod X
-  (include *standard-cl-23*)
+  (include *standard-cl-21*)
 
   (defun F Xs
     (if Xs
@@ -499,7 +499,7 @@ fn test_ni_ni_rest_call_25() {
 fn test_ni_ni_exact_improper_no_tail_26() {
     let prog = indoc! {"
 (mod (X Y)
-  (include *standard-cl-23*)
+  (include *standard-cl-21*)
 
   (defun F (A B . C) (+ A B C))
 
@@ -516,7 +516,7 @@ fn test_ni_ni_exact_improper_no_tail_26() {
 fn test_simple_inline_exact_toofew_improper_tail_27() {
     let prog = indoc! {"
 (mod (X Y Z)
-  (include *standard-cl-23*)
+  (include *standard-cl-21*)
 
   (defun F (A B C . D) (list A B C (f D)))
 
@@ -533,7 +533,7 @@ fn test_simple_inline_exact_toofew_improper_tail_27() {
 fn test_ni_ni_exact_toofew_tail_28() {
     let prog = indoc! {"
 (mod (X Y Z)
-  (include *standard-cl-23*)
+  (include *standard-cl-21*)
 
   (defun F (A B C) (list A B C))
 
@@ -550,7 +550,7 @@ fn test_ni_ni_exact_toofew_tail_28() {
 fn test_ni_ni_exact_toofew_improper_no_tail_29() {
     let prog = indoc! {"
 (mod (X Y)
-  (include *standard-cl-23*)
+  (include *standard-cl-21*)
 
   (defun F (A B C . D) (list A B C (f D)))
 
@@ -571,7 +571,7 @@ fn test_ni_ni_exact_toofew_improper_no_tail_29() {
 fn test_ni_ni_exact_toofew_tail_30() {
     let prog = indoc! {"
 (mod (X Y Z)
-  (include *standard-cl-23*)
+  (include *standard-cl-21*)
 
   (defun F (A B C) (list A B C))
 
@@ -588,7 +588,7 @@ fn test_ni_ni_exact_toofew_tail_30() {
 fn test_inline_ni_toomany_args_31() {
     let prog = indoc! {"
 (mod (X Y Z)
-  (include *standard-cl-23*)
+  (include *standard-cl-21*)
 
   (defun F (A B) (+ A B))
 
@@ -605,7 +605,7 @@ fn test_inline_ni_toomany_args_31() {
 fn test_inline_ni_toomany_args_improper_tail_32() {
     let prog = indoc! {"
 (mod (X Y Z)
-  (include *standard-cl-23*)
+  (include *standard-cl-21*)
 
   (defun return-list (Xs) Xs)
 
@@ -622,7 +622,7 @@ fn test_inline_ni_toomany_args_improper_tail_32() {
 fn test_simple_inline_toomany_args_improper_no_tail_33() {
     let prog = indoc! {"
 (mod (X Y)
-  (include *standard-cl-23*)
+  (include *standard-cl-21*)
 
   (defun return-list (Xs) Xs)
 
@@ -639,7 +639,7 @@ fn test_simple_inline_toomany_args_improper_no_tail_33() {
 fn test_inline_ni_exact_no_tails_34() {
     let prog = indoc! {"
 (mod (X Y)
-  (include *standard-cl-23*)
+  (include *standard-cl-21*)
 
   (defun F (A B) (* A B))
 
@@ -656,7 +656,7 @@ fn test_inline_ni_exact_no_tails_34() {
 fn test_inline_ni_exact_improper_tail_35() {
     let prog = indoc! {"
 (mod (X Y Z)
-  (include *standard-cl-23*)
+  (include *standard-cl-21*)
 
   (defun F (A B . C) (* A B C))
 
@@ -673,7 +673,7 @@ fn test_inline_ni_exact_improper_tail_35() {
 fn test_simple_rest_call_inline_35() {
     let prog = indoc! {"
 (mod X
-  (include *standard-cl-23*)
+  (include *standard-cl-21*)
 
   (defun sum (Xs)
     (if Xs
@@ -695,7 +695,7 @@ fn test_simple_rest_call_inline_35() {
 fn test_inline_ni_exact_improper_no_tail_36() {
     let prog = indoc! {"
 (mod (X Y)
-  (include *standard-cl-23*)
+  (include *standard-cl-21*)
 
   (defun F (A B . C) (+ A B C))
 
@@ -712,7 +712,7 @@ fn test_inline_ni_exact_improper_no_tail_36() {
 fn test_simple_inline_exact_toofew_improper_tail_37() {
     let prog = indoc! {"
 (mod (X Y Z)
-  (include *standard-cl-23*)
+  (include *standard-cl-21*)
 
   (defun F (A B C . D) (list A B C (f D)))
 
@@ -729,7 +729,7 @@ fn test_simple_inline_exact_toofew_improper_tail_37() {
 fn test_inline_ni_exact_toofew_tail_38() {
     let prog = indoc! {"
 (mod (X Y Z)
-  (include *standard-cl-23*)
+  (include *standard-cl-21*)
 
   (defun F (A B C) (list A B C))
 
@@ -746,7 +746,7 @@ fn test_inline_ni_exact_toofew_tail_38() {
 fn test_inline_ni_exact_toofew_improper_no_tail_39() {
     let prog = indoc! {"
 (mod (X Y)
-  (include *standard-cl-23*)
+  (include *standard-cl-21*)
 
   (defun F (A B C . D) (list A B C (f D)))
 
@@ -767,7 +767,7 @@ fn test_inline_ni_exact_toofew_improper_no_tail_39() {
 fn test_inline_ni_exact_toofew_tail_40() {
     let prog = indoc! {"
 (mod (X Y Z)
-  (include *standard-cl-23*)
+  (include *standard-cl-21*)
 
   (defun F (A B C) (list A B C))
 

--- a/src/tests/compiler/restargs.rs
+++ b/src/tests/compiler/restargs.rs
@@ -896,8 +896,8 @@ fn test_repl_10() {
             "(defun F (A B C) (list A B C))",
             "(F 5 7 &rest (list 101 103))"
         ])
-            .unwrap()
-            .unwrap(),
+        .unwrap()
+        .unwrap(),
         "(q 5 7 101)"
     );
 }
@@ -943,8 +943,8 @@ fn test_repl_tail_let() {
             "(defun F (A B C D) (list A B C D))",
             "(F 5 7 &rest (let ((Q (list 101 103))) (c 99 Q)))"
         ])
-            .unwrap()
-            .unwrap(),
+        .unwrap()
+        .unwrap(),
         "(q 5 7 99 101)"
     );
 }

--- a/src/tests/compiler/restargs.rs
+++ b/src/tests/compiler/restargs.rs
@@ -1,0 +1,903 @@
+use crate::tests::compiler::compiler::run_string;
+use crate::tests::compiler::repl::test_repl_outcome;
+
+// All tests needed for rest calls:
+//
+// Call from non-inline to inline
+// 01 - Too many arguments, no tail position argument to absorb.
+// 02 - Too many arguments, tail position argument to absorb, &rest.
+// 03 - Too many arguments, tail position argument to absorb, no &rest.
+// 04 - Exact number of arguments, no tail position argument.
+// 05 - Exact number of arguments, tail position argument, &rest.
+// 06 - Exact number of arguments, tail position argument, no &rest.
+// 07 - Too few arguments, &rest, tail.
+// 08 - Too few arguments, &rest, no tail.
+// 09 - Too few arguments, no &rest, tail. (error)
+// 10 - Too few arguments, &rest, no tail.
+// Call from inline to inline
+// 11 - Too many arguments, no tail position argument to absorb.
+// 12 - Too many arguments, tail position argument to absorb, &rest.
+// 13 - Too many arguments, tail position argument to absorb, no &rest.
+// 14 - Exact number of arguments, no tail position argument.
+// 15 - Exact number of arguments, tail position argument, &rest.
+// 16 - Exact number of arguments, tail position argument, no &rest.
+// 17 - Too few arguments, &rest, tail.
+// 18 - Too few arguments, &rest, no tail.
+// 19 - Too few arguments, no &rest, tail. (error)
+// 20 - Too few arguments, &rest, no tail.
+// Call from non-inline to non-inline
+// 21 - Too many arguments, no tail position argument to absorb.
+// 22 - Too many arguments, tail position argument to absorb, &rest.
+// 23 - Too many arguments, tail position argument to absorb, no &rest.
+// 24 - Exact number of arguments, no tail position argument.
+// 25 - Exact number of arguments, tail position argument, &rest.
+// 26 - Exact number of arguments, tail position argument, no &rest.
+// 27 - Too few arguments, &rest, tail.
+// 28 - Too few arguments, &rest, no tail.
+// 29 - Too few arguments, no &rest, tail. (not error)
+// 30 - Too few arguments, &rest, no tail.
+// Call from inline to non-inline
+// 31 - Too many arguments, no tail position argument to absorb.
+// 32 - Too many arguments, tail position argument to absorb, &rest.
+// 33 - Too many arguments, tail position argument to absorb, no &rest.
+// 34 - Exact number of arguments, no tail position argument.
+// 35 - Exact number of arguments, tail position argument, &rest.
+// 36 - Exact number of arguments, tail position argument, no &rest.
+// 37 - Too few arguments, &rest, tail.
+// 38 - Too few arguments, &rest, no tail.
+// 39 - Too few arguments, no &rest, tail. (not error)
+// 40 - Too few arguments, &rest, no tail.
+//
+#[test]
+fn test_simple_inline_toomany_args_01() {
+    let prog = indoc! {"
+(mod (X Y Z)
+  (include *standard-cl-23*)
+
+  (defun-inline F (A B) (+ A B))
+
+  (F X Y Z)
+  )"}
+    .to_string();
+    let res = run_string(&prog, &"(5 7 9)".to_string()).expect("should compile and run");
+    assert_eq!(res.to_string(), "12");
+}
+
+#[test]
+fn test_simple_inline_toomany_args_improper_tail_02() {
+    let prog = indoc! {"
+(mod (X Y Z)
+  (include *standard-cl-23*)
+
+  (defun sum (Xs)
+    (if Xs
+      (+ (f Xs) (sum (r Xs)))
+      ()
+      )
+    )
+
+  (defun-inline F (A B . C) (* A B (sum C)))
+
+  (F X Y 99 101 &rest Z)
+  )"}
+    .to_string();
+    let res = run_string(&prog, &"(5 7 (301 313))".to_string()).expect("should compile and run");
+    assert_eq!(res.to_string(), "28490");
+}
+
+#[test]
+fn test_simple_inline_toomany_args_improper_no_tail_03() {
+    let prog = indoc! {"
+(mod (X Y)
+  (include *standard-cl-23*)
+
+  (defun sum (Xs)
+    (if Xs
+      (+ (f Xs) (sum (r Xs)))
+      ()
+      )
+    )
+
+  (defun-inline F (A B . C) (* A B (sum C)))
+
+  (F X Y 99 101)
+  )"}
+    .to_string();
+    let res = run_string(&prog, &"(5 7)".to_string()).expect("should compile and run");
+    assert_eq!(res.to_string(), "7000");
+}
+
+#[test]
+fn test_simple_inline_exact_no_tails_04() {
+    let prog = indoc! {"
+(mod (X Y)
+  (include *standard-cl-23*)
+
+  (defun-inline F (A B) (* A B))
+
+  (F X Y)
+  )"}
+    .to_string();
+    let res = run_string(&prog, &"(5 7)".to_string()).expect("should compile and run");
+    assert_eq!(res.to_string(), "35");
+}
+
+#[test]
+fn test_simple_inline_exact_improper_tail_05() {
+    let prog = indoc! {"
+(mod (X Y Z)
+  (include *standard-cl-23*)
+
+  (defun-inline F (A B . C) (* A B C))
+
+  (F X Y &rest Z)
+  )"}
+    .to_string();
+    let res = run_string(&prog, &"(5 7 9)".to_string()).expect("should compile and run");
+    assert_eq!(res.to_string(), "315");
+}
+
+#[test]
+fn test_simple_inline_exact_improper_no_tail_06() {
+    let prog = indoc! {"
+(mod (X Y)
+  (include *standard-cl-23*)
+
+  (defun-inline F (A B . C) (+ A B C))
+
+  (F X Y)
+  )"}
+    .to_string();
+    let res = run_string(&prog, &"(5 7)".to_string()).expect("should compile and run");
+    assert_eq!(res.to_string(), "12");
+}
+
+#[test]
+fn test_simple_inline_exact_toofew_improper_tail_07() {
+    let prog = indoc! {"
+(mod (X Y Z)
+  (include *standard-cl-23*)
+
+  (defun-inline F (A B C . D) (list A B C (f D)))
+
+  (F X Y &rest Z)
+  )"}
+    .to_string();
+    let res = run_string(&prog, &"(5 7 (101 103))".to_string()).expect("should compile and run");
+    assert_eq!(res.to_string(), "(5 7 101 103)");
+}
+
+#[test]
+fn test_simple_inline_exact_toofew_tail_08() {
+    let prog = indoc! {"
+(mod (X Y Z)
+  (include *standard-cl-23*)
+
+  (defun-inline F (A B C) (list A B C))
+
+  (F X Y &rest Z)
+  )"}
+    .to_string();
+    let res = run_string(&prog, &"(5 7 (101 103))".to_string()).expect("should compile and run");
+    assert_eq!(res.to_string(), "(5 7 101)");
+}
+
+#[test]
+fn test_simple_inline_exact_toofew_improper_no_tail_09() {
+    let prog = indoc! {"
+(mod (X Y)
+  (include *standard-cl-23*)
+
+  (defun-inline F (A B C . D) (list A B C (f D)))
+
+  (F X Y)
+  )"}
+    .to_string();
+    let res = run_string(&prog, &"(5 7)".to_string());
+    if let Err(e) = res {
+        assert!(e.1.contains("Lookup for argument 3"));
+    } else {
+        assert!(false);
+    }
+}
+
+#[test]
+fn test_simple_inline_exact_toofew_tail_10() {
+    let prog = indoc! {"
+(mod (X Y Z)
+  (include *standard-cl-23*)
+
+  (defun-inline F (A B C) (list A B C))
+
+  (F X Y &rest Z)
+  )"}
+    .to_string();
+    let res = run_string(&prog, &"(5 7 (101 103))".to_string()).expect("should compile and run");
+    assert_eq!(res.to_string(), "(5 7 101)");
+}
+
+#[test]
+fn test_inline_inline_toomany_args_11() {
+    let prog = indoc! {"
+(mod (X Y Z)
+  (include *standard-cl-23*)
+
+  (defun-inline F (A B) (+ A B))
+
+  (defun-inline G (X Y Z) (F X Y Z))
+
+  (G X Y Z)
+  )"}
+    .to_string();
+    let res = run_string(&prog, &"(5 7 9)".to_string()).expect("should compile and run");
+    assert_eq!(res.to_string(), "12");
+}
+
+#[test]
+fn test_inline_inline_toomany_args_improper_tail_12() {
+    let prog = indoc! {"
+(mod (X Y Z)
+  (include *standard-cl-23*)
+
+  (defun-inline return-list (Xs) Xs)
+
+  (defun-inline F (A B . C) (list A B (return-list C)))
+
+  (F X Y 99 101 &rest Z)
+  )"}
+    .to_string();
+    let res = run_string(&prog, &"(5 7 (301 313))".to_string()).expect("should compile and run");
+    assert_eq!(res.to_string(), "(5 7 (c e 301 313))");
+}
+
+#[test]
+fn test_simple_inline_toomany_args_improper_no_tail_13() {
+    let prog = indoc! {"
+(mod (X Y)
+  (include *standard-cl-23*)
+
+  (defun-inline return-list (Xs) Xs)
+
+  (defun-inline F (A B . C) (list A B (return-list C)))
+
+  (F X Y 99 101)
+  )"}
+    .to_string();
+    let res = run_string(&prog, &"(5 7)".to_string()).expect("should compile and run");
+    assert_eq!(res.to_string(), "(5 7 (c e))");
+}
+
+#[test]
+fn test_inline_inline_exact_no_tails_14() {
+    let prog = indoc! {"
+(mod (X Y)
+  (include *standard-cl-23*)
+
+  (defun-inline F (A B) (* A B))
+
+  (defun-inline G (A B) (F A B))
+
+  (G X Y)
+  )"}
+    .to_string();
+    let res = run_string(&prog, &"(5 7)".to_string()).expect("should compile and run");
+    assert_eq!(res.to_string(), "35");
+}
+
+#[test]
+fn test_inline_inline_exact_improper_tail_15() {
+    let prog = indoc! {"
+(mod (X Y Z)
+  (include *standard-cl-23*)
+
+  (defun-inline F (A B . C) (* A B C))
+
+  (defun-inline G (X Y Z) (F X Y &rest Z))
+
+  (G X Y Z)
+  )"}
+    .to_string();
+    let res = run_string(&prog, &"(5 7 9)".to_string()).expect("should compile and run");
+    assert_eq!(res.to_string(), "315");
+}
+
+#[test]
+fn test_inline_inline_exact_improper_no_tail_16() {
+    let prog = indoc! {"
+(mod (X Y)
+  (include *standard-cl-23*)
+
+  (defun-inline F (A B . C) (+ A B C))
+
+  (defun-inline G (X Y) (F X Y))
+
+  (G X Y)
+  )"}
+    .to_string();
+    let res = run_string(&prog, &"(5 7)".to_string()).expect("should compile and run");
+    assert_eq!(res.to_string(), "12");
+}
+
+#[test]
+fn test_simple_inline_exact_toofew_improper_tail_17() {
+    let prog = indoc! {"
+(mod (X Y Z)
+  (include *standard-cl-23*)
+
+  (defun-inline F (A B C . D) (list A B C (f D)))
+
+  (defun-inline G (X Y Z) (F X Y &rest Z))
+
+  (G X Y Z)
+  )"}
+    .to_string();
+    let res = run_string(&prog, &"(5 7 (101 103))".to_string()).expect("should compile and run");
+    assert_eq!(res.to_string(), "(5 7 101 103)");
+}
+
+#[test]
+fn test_inline_inline_exact_toofew_tail_18() {
+    let prog = indoc! {"
+(mod (X Y Z)
+  (include *standard-cl-23*)
+
+  (defun-inline F (A B C) (list A B C))
+
+  (defun-inline G (X Y Z) (F X Y &rest Z))
+
+  (G X Y Z)
+  )"}
+    .to_string();
+    let res = run_string(&prog, &"(5 7 (101 103))".to_string()).expect("should compile and run");
+    assert_eq!(res.to_string(), "(5 7 101)");
+}
+
+#[test]
+fn test_inline_inline_exact_toofew_improper_no_tail_19() {
+    let prog = indoc! {"
+(mod (X Y)
+  (include *standard-cl-23*)
+
+  (defun-inline F (A B C . D) (list A B C (f D)))
+
+  (defun-inline G (X Y) (F X Y))
+
+  (G X Y)
+  )"}
+    .to_string();
+    let res = run_string(&prog, &"(5 7)".to_string());
+    if let Err(e) = res {
+        assert!(e.1.contains("Lookup for argument 3"));
+    } else {
+        assert!(false);
+    }
+}
+
+#[test]
+fn test_simple_inline_exact_toofew_tail_20() {
+    let prog = indoc! {"
+(mod (X Y Z)
+  (include *standard-cl-23*)
+
+  (defun-inline F (A B C) (list A B C))
+
+  (defun-inline G (X Y Z) (F X Y &rest Z))
+
+  (G X Y Z)
+  )"}
+    .to_string();
+    let res = run_string(&prog, &"(5 7 (101 103))".to_string()).expect("should compile and run");
+    assert_eq!(res.to_string(), "(5 7 101)");
+}
+
+#[test]
+fn test_ni_ni_toomany_args_21() {
+    let prog = indoc! {"
+(mod (X Y Z)
+  (include *standard-cl-23*)
+
+  (defun F (A B) (+ A B))
+
+  (defun G (X Y Z) (F X Y Z))
+
+  (G X Y Z)
+  )"}
+    .to_string();
+    let res = run_string(&prog, &"(5 7 9)".to_string()).expect("should compile and run");
+    assert_eq!(res.to_string(), "12");
+}
+
+#[test]
+fn test_ni_ni_toomany_args_improper_tail_22() {
+    let prog = indoc! {"
+(mod (X Y Z)
+  (include *standard-cl-23*)
+
+  (defun return-list (Xs) Xs)
+
+  (defun F (A B . C) (list A B (return-list C)))
+
+  (F X Y 99 101 &rest Z)
+  )"}
+    .to_string();
+    let res = run_string(&prog, &"(5 7 (301 313))".to_string()).expect("should compile and run");
+    assert_eq!(res.to_string(), "(5 7 (c e 301 313))");
+}
+
+#[test]
+fn test_simple_inline_toomany_args_improper_no_tail_23() {
+    let prog = indoc! {"
+(mod (X Y)
+  (include *standard-cl-23*)
+
+  (defun return-list (Xs) Xs)
+
+  (defun F (A B . C) (list A B (return-list C)))
+
+  (F X Y 99 101)
+  )"}
+    .to_string();
+    let res = run_string(&prog, &"(5 7)".to_string()).expect("should compile and run");
+    assert_eq!(res.to_string(), "(5 7 (c e))");
+}
+
+#[test]
+fn test_ni_ni_exact_no_tails_24() {
+    let prog = indoc! {"
+(mod (X Y)
+  (include *standard-cl-23*)
+
+  (defun F (A B) (* A B))
+
+  (defun G (A B) (F A B))
+
+  (G X Y)
+  )"}
+    .to_string();
+    let res = run_string(&prog, &"(5 7)".to_string()).expect("should compile and run");
+    assert_eq!(res.to_string(), "35");
+}
+
+#[test]
+fn test_ni_ni_exact_improper_tail_25() {
+    let prog = indoc! {"
+(mod (X Y Z)
+  (include *standard-cl-23*)
+
+  (defun F (A B . C) (* A B C))
+
+  (defun G (X Y Z) (F X Y &rest Z))
+
+  (G X Y Z)
+  )"}
+    .to_string();
+    let res = run_string(&prog, &"(5 7 9)".to_string()).expect("should compile and run");
+    assert_eq!(res.to_string(), "315");
+}
+
+#[test]
+fn test_ni_ni_rest_call_25() {
+    let prog = indoc! {"
+(mod X
+  (include *standard-cl-23*)
+
+  (defun F Xs
+    (if Xs
+      (+ (f Xs) (F &rest (r Xs)))
+      ()
+      )
+    )
+
+  (F &rest X)
+  )"}
+    .to_string();
+    let res = run_string(&prog, &"(13 99 144)".to_string()).expect("should compile and run");
+    assert_eq!(res.to_string(), "256");
+}
+
+#[test]
+fn test_ni_ni_exact_improper_no_tail_26() {
+    let prog = indoc! {"
+(mod (X Y)
+  (include *standard-cl-23*)
+
+  (defun F (A B . C) (+ A B C))
+
+  (defun G (X Y) (F X Y))
+
+  (G X Y)
+  )"}
+    .to_string();
+    let res = run_string(&prog, &"(5 7)".to_string()).expect("should compile and run");
+    assert_eq!(res.to_string(), "12");
+}
+
+#[test]
+fn test_simple_inline_exact_toofew_improper_tail_27() {
+    let prog = indoc! {"
+(mod (X Y Z)
+  (include *standard-cl-23*)
+
+  (defun F (A B C . D) (list A B C (f D)))
+
+  (defun G (X Y Z) (F X Y &rest Z))
+
+  (G X Y Z)
+  )"}
+    .to_string();
+    let res = run_string(&prog, &"(5 7 (101 103))".to_string()).expect("should compile and run");
+    assert_eq!(res.to_string(), "(5 7 101 103)");
+}
+
+#[test]
+fn test_ni_ni_exact_toofew_tail_28() {
+    let prog = indoc! {"
+(mod (X Y Z)
+  (include *standard-cl-23*)
+
+  (defun F (A B C) (list A B C))
+
+  (defun G (X Y Z) (F X Y &rest Z))
+
+  (G X Y Z)
+  )"}
+    .to_string();
+    let res = run_string(&prog, &"(5 7 (101 103))".to_string()).expect("should compile and run");
+    assert_eq!(res.to_string(), "(5 7 101)");
+}
+
+#[test]
+fn test_ni_ni_exact_toofew_improper_no_tail_29() {
+    let prog = indoc! {"
+(mod (X Y)
+  (include *standard-cl-23*)
+
+  (defun F (A B C . D) (list A B C (f D)))
+
+  (defun G (X Y) (F X Y))
+
+  (G X Y)
+  )"}
+    .to_string();
+    let res = run_string(&prog, &"(5 7)".to_string());
+    if let Err(e) = res {
+        assert!(e.1.contains("bad path"));
+    } else {
+        assert!(false);
+    }
+}
+
+#[test]
+fn test_ni_ni_exact_toofew_tail_30() {
+    let prog = indoc! {"
+(mod (X Y Z)
+  (include *standard-cl-23*)
+
+  (defun F (A B C) (list A B C))
+
+  (defun G (X Y Z) (F X Y &rest Z))
+
+  (G X Y Z)
+  )"}
+    .to_string();
+    let res = run_string(&prog, &"(5 7 (101 103))".to_string()).expect("should compile and run");
+    assert_eq!(res.to_string(), "(5 7 101)");
+}
+
+#[test]
+fn test_inline_ni_toomany_args_31() {
+    let prog = indoc! {"
+(mod (X Y Z)
+  (include *standard-cl-23*)
+
+  (defun F (A B) (+ A B))
+
+  (defun-inline G (X Y Z) (F X Y Z))
+
+  (G X Y Z)
+  )"}
+    .to_string();
+    let res = run_string(&prog, &"(5 7 9)".to_string()).expect("should compile and run");
+    assert_eq!(res.to_string(), "12");
+}
+
+#[test]
+fn test_inline_ni_toomany_args_improper_tail_32() {
+    let prog = indoc! {"
+(mod (X Y Z)
+  (include *standard-cl-23*)
+
+  (defun return-list (Xs) Xs)
+
+  (defun F (A B . C) (list A B (return-list C)))
+
+  (F X Y 99 101 &rest Z)
+  )"}
+    .to_string();
+    let res = run_string(&prog, &"(5 7 (301 313))".to_string()).expect("should compile and run");
+    assert_eq!(res.to_string(), "(5 7 (c e 301 313))");
+}
+
+#[test]
+fn test_simple_inline_toomany_args_improper_no_tail_33() {
+    let prog = indoc! {"
+(mod (X Y)
+  (include *standard-cl-23*)
+
+  (defun return-list (Xs) Xs)
+
+  (defun F (A B . C) (list A B (return-list C)))
+
+  (F X Y 99 101)
+  )"}
+    .to_string();
+    let res = run_string(&prog, &"(5 7)".to_string()).expect("should compile and run");
+    assert_eq!(res.to_string(), "(5 7 (c e))");
+}
+
+#[test]
+fn test_inline_ni_exact_no_tails_34() {
+    let prog = indoc! {"
+(mod (X Y)
+  (include *standard-cl-23*)
+
+  (defun F (A B) (* A B))
+
+  (defun-inline G (A B) (F A B))
+
+  (G X Y)
+  )"}
+    .to_string();
+    let res = run_string(&prog, &"(5 7)".to_string()).expect("should compile and run");
+    assert_eq!(res.to_string(), "35");
+}
+
+#[test]
+fn test_inline_ni_exact_improper_tail_35() {
+    let prog = indoc! {"
+(mod (X Y Z)
+  (include *standard-cl-23*)
+
+  (defun F (A B . C) (* A B C))
+
+  (defun-inline G (X Y Z) (F X Y &rest Z))
+
+  (G X Y Z)
+  )"}
+    .to_string();
+    let res = run_string(&prog, &"(5 7 9)".to_string()).expect("should compile and run");
+    assert_eq!(res.to_string(), "315");
+}
+
+#[test]
+fn test_simple_rest_call_inline_35() {
+    let prog = indoc! {"
+(mod X
+  (include *standard-cl-23*)
+
+  (defun sum (Xs)
+    (if Xs
+      (+ (f Xs) (sum (r Xs)))
+      ()
+      )
+    )
+
+  (defun-inline F (A1 . A2) (* A1 (sum A2)))
+
+  (F 3 &rest X)
+  )"}
+    .to_string();
+    let res = run_string(&prog, &"(13 99 144)".to_string()).expect("should compile and run");
+    assert_eq!(res.to_string(), "768");
+}
+
+#[test]
+fn test_inline_ni_exact_improper_no_tail_36() {
+    let prog = indoc! {"
+(mod (X Y)
+  (include *standard-cl-23*)
+
+  (defun F (A B . C) (+ A B C))
+
+  (defun-inline G (X Y) (F X Y))
+
+  (G X Y)
+  )"}
+    .to_string();
+    let res = run_string(&prog, &"(5 7)".to_string()).expect("should compile and run");
+    assert_eq!(res.to_string(), "12");
+}
+
+#[test]
+fn test_simple_inline_exact_toofew_improper_tail_37() {
+    let prog = indoc! {"
+(mod (X Y Z)
+  (include *standard-cl-23*)
+
+  (defun F (A B C . D) (list A B C (f D)))
+
+  (defun-inline G (X Y Z) (F X Y &rest Z))
+
+  (G X Y Z)
+  )"}
+    .to_string();
+    let res = run_string(&prog, &"(5 7 (101 103))".to_string()).expect("should compile and run");
+    assert_eq!(res.to_string(), "(5 7 101 103)");
+}
+
+#[test]
+fn test_inline_ni_exact_toofew_tail_38() {
+    let prog = indoc! {"
+(mod (X Y Z)
+  (include *standard-cl-23*)
+
+  (defun F (A B C) (list A B C))
+
+  (defun-inline G (X Y Z) (F X Y &rest Z))
+
+  (G X Y Z)
+  )"}
+    .to_string();
+    let res = run_string(&prog, &"(5 7 (101 103))".to_string()).expect("should compile and run");
+    assert_eq!(res.to_string(), "(5 7 101)");
+}
+
+#[test]
+fn test_inline_ni_exact_toofew_improper_no_tail_39() {
+    let prog = indoc! {"
+(mod (X Y)
+  (include *standard-cl-23*)
+
+  (defun F (A B C . D) (list A B C (f D)))
+
+  (defun-inline G (X Y) (F X Y))
+
+  (G X Y)
+  )"}
+    .to_string();
+    let res = run_string(&prog, &"(5 7)".to_string());
+    if let Err(e) = res {
+        assert!(e.1.contains("bad path"));
+    } else {
+        assert!(false);
+    }
+}
+
+#[test]
+fn test_inline_ni_exact_toofew_tail_40() {
+    let prog = indoc! {"
+(mod (X Y Z)
+  (include *standard-cl-23*)
+
+  (defun F (A B C) (list A B C))
+
+  (defun-inline G (X Y Z) (F X Y &rest Z))
+
+  (G X Y Z)
+  )"}
+    .to_string();
+    let res = run_string(&prog, &"(5 7 (101 103))".to_string()).expect("should compile and run");
+    assert_eq!(res.to_string(), "(5 7 101)");
+}
+
+#[test]
+fn test_repl_01() {
+    assert_eq!(
+        test_repl_outcome(vec!["(defun-inline F (A B) (+ A B))", "(F 5 7 9)"])
+            .unwrap()
+            .unwrap(),
+        "(q . 12)"
+    );
+}
+
+const REPL_TEST_SUM: &'static str = indoc! {"
+(defun sum (Xs)
+    (if Xs
+      (+ (f Xs) (sum (r Xs)))
+      ()
+      )
+    )"};
+
+#[test]
+fn test_repl_02() {
+    assert_eq!(
+        test_repl_outcome(vec![
+            REPL_TEST_SUM,
+            "(defun-inline F (A B . C) (* A B (sum C)))",
+            "(F 5 7 99 101 &rest (list 301 313))"
+        ])
+        .unwrap()
+        .unwrap(),
+        "(q . 28490)"
+    );
+}
+
+#[test]
+fn test_repl_03() {
+    assert_eq!(
+        test_repl_outcome(vec![
+            REPL_TEST_SUM,
+            "(defun-inline F (A B . C) (* A B (sum C)))",
+            "(F 5 7 99 101)"
+        ])
+        .unwrap()
+        .unwrap(),
+        "(q . 7000)"
+    );
+}
+
+#[test]
+fn test_repl_04() {
+    assert_eq!(
+        test_repl_outcome(vec!["(defun F (A B) (* A B))", "(F 5 7)"])
+            .unwrap()
+            .unwrap(),
+        "(q . 35)"
+    );
+}
+
+#[test]
+fn test_repl_05() {
+    assert_eq!(
+        test_repl_outcome(vec!["(defun F (A B . C) (* A B C))", "(F 5 7 &rest 9)"])
+            .unwrap()
+            .unwrap(),
+        "(q . 315)"
+    );
+}
+
+#[test]
+fn test_repl_06() {
+    assert_eq!(
+        test_repl_outcome(vec!["(defun F (A B . C) (+ A B C))", "(F 5 7)"])
+            .unwrap()
+            .unwrap(),
+        "(q . 12)"
+    );
+}
+
+#[test]
+fn test_repl_07() {
+    assert_eq!(
+        test_repl_outcome(vec![
+            "(defun F (A B C . D) (list A B C (f D)))",
+            "(F 5 7 &rest (list 101 103))"
+        ])
+        .unwrap()
+        .unwrap(),
+        "(q 5 7 101 103)"
+    );
+}
+
+#[test]
+fn test_repl_08() {
+    assert_eq!(
+        test_repl_outcome(vec![
+            "(defun F (A B C) (list A B C))",
+            "(F 5 7 &rest (list 101 103))"
+        ])
+        .unwrap()
+        .unwrap(),
+        "(q 5 7 101)"
+    );
+}
+
+#[test]
+fn test_repl_09() {
+    assert!(
+        test_repl_outcome(vec!["(defun F (A B C . D) (list A B C (f D)))", "(F 5 7)"]).is_err()
+    );
+}
+
+#[test]
+fn test_repl_10() {
+    assert_eq!(
+        test_repl_outcome(vec![
+            "(defun F (A B C) (list A B C))",
+            "(F 5 7 &rest (list 101 103))"
+        ])
+        .unwrap()
+        .unwrap(),
+        "(q 5 7 101)"
+    );
+}


### PR DESCRIPTION
This is &rest arguments from https://github.com/Chia-Network/clvm_tools_rs/pull/198 backported to base.
The purpose of this is to ensure that the merge flows properly from a base PR to a nightly PR to nightly so that future changes to base also flow properly on top of this complex merge traffic.  It's also the case that these have the possibility of merging to base separately eventually, since they're each smaller, self contained features.