### PR TITLE
Recognize a list as proper when it has a weird but not non-nil tail

### DIFF
--- a/src/compiler/clvm.rs
+++ b/src/compiler/clvm.rs
@@ -192,10 +192,21 @@ fn eval_args(
                 sexp = b.clone();
             }
             _ => {
-                return Err(RunFailure::RunErr(
-                    sexp.loc(),
-                    format!("bad argument list {sexp_} {context_}"),
-                ));
+                // A list of the following forms:
+                //   (x y . 0)
+                //   (x y . "")
+                // Are properly terminated lists and disassemble to (x y).
+                //
+                // This recognizes that our broader value space has more ways
+                // of expressing nil.
+                if !truthy(sexp.clone()) {
+                    return Ok(RunStep::Op(head, context_, sexp, Some(eval_list), parent));
+                } else {
+                    return Err(RunFailure::RunErr(
+                        sexp.loc(),
+                        format!("bad argument list {sexp_} {context_}"),
+                    ));
+                }
             }
         }
     }

--- a/src/compiler/clvm.rs
+++ b/src/compiler/clvm.rs
@@ -183,31 +183,23 @@ fn eval_args(
     let mut eval_list: Vec<Rc<SExp>> = Vec::new();
 
     loop {
-        match sexp.borrow() {
-            SExp::Nil(_l) => {
-                return Ok(RunStep::Op(head, context_, sexp, Some(eval_list), parent));
-            }
-            SExp::Cons(_l, a, b) => {
-                eval_list.push(a.clone());
-                sexp = b.clone();
-            }
-            _ => {
-                // A list of the following forms:
-                //   (x y . 0)
-                //   (x y . "")
-                // Are properly terminated lists and disassemble to (x y).
-                //
-                // This recognizes that our broader value space has more ways
-                // of expressing nil.
-                if !truthy(sexp.clone()) {
-                    return Ok(RunStep::Op(head, context_, sexp, Some(eval_list), parent));
-                } else {
-                    return Err(RunFailure::RunErr(
-                        sexp.loc(),
-                        format!("bad argument list {sexp_} {context_}"),
-                    ));
-                }
-            }
+        // A list of the following forms:
+        //   (x y . 0)
+        //   (x y . "")
+        // Are properly terminated lists and disassemble to (x y).
+        //
+        // This recognizes that our broader value space has more ways
+        // of expressing nil.
+        if let SExp::Cons(_l, a, b) = sexp.borrow() {
+            eval_list.push(a.clone());
+            sexp = b.clone();
+        } else if !truthy(sexp.clone()) {
+            return Ok(RunStep::Op(head, context_, sexp, Some(eval_list), parent));
+        } else {
+            return Err(RunFailure::RunErr(
+                sexp.loc(),
+                format!("bad argument list {sexp_} {context_}"),
+            ));
         }
     }
 }

--- a/src/tests/compiler/cldb.rs
+++ b/src/tests/compiler/cldb.rs
@@ -369,3 +369,29 @@ fn test_cldb_explicit_throw() {
 
     assert!(watcher.correct_result());
 }
+
+#[test]
+fn test_clvm_operator_with_weird_tail() {
+    let filename = "test-weird-tail.clvm";
+    let loc = Srcloc::start(filename);
+    let program = "(+ (q . 3) (q . 5) . \"\")";
+    let parsed = parse_sexp(
+        loc.clone(),
+        program.as_bytes().iter().copied(),
+    )
+        .expect("should parse");
+    let args = Rc::new(SExp::Nil(loc));
+    let program_lines = Rc::new(vec![program.to_string()]);
+
+    assert_eq!(
+        run_clvm_in_cldb(
+            filename,
+            program_lines,
+            parsed[0].clone(),
+            HashMap::new(),
+            args,
+            &mut DoesntWatchCldb {},
+        ),
+        Some("8".to_string())
+    );
+}

--- a/src/tests/compiler/cldb.rs
+++ b/src/tests/compiler/cldb.rs
@@ -375,11 +375,7 @@ fn test_clvm_operator_with_weird_tail() {
     let filename = "test-weird-tail.clvm";
     let loc = Srcloc::start(filename);
     let program = "(+ (q . 3) (q . 5) . \"\")";
-    let parsed = parse_sexp(
-        loc.clone(),
-        program.as_bytes().iter().copied(),
-    )
-        .expect("should parse");
+    let parsed = parse_sexp(loc.clone(), program.as_bytes().iter().copied()).expect("should parse");
     let args = Rc::new(SExp::Nil(loc));
     let program_lines = Rc::new(vec![program.to_string()]);
 


### PR DESCRIPTION
This came up when working on the lambda pr.  Hopefully uncontroversial bug fix to allow clvm lists tailed by nil values that have some other representation than SExp::Nil to tail operator argument lists.