### PR TITLE
Changes to sexp.rs's handling of termlist and clone optimisations

### DIFF
--- a/src/compiler/sexp.rs
+++ b/src/compiler/sexp.rs
@@ -671,7 +671,7 @@ fn parse_sexp_step(loc: Srcloc, current_state: &SExpParseState, this_char: u8) -
                     SExpParseResult::Error(l, e) => SExpParseResult::Error(l, e), // propagate error upwards
                 },
             }
-        },
+        }
 
         // if we're not in a comment and have already found a parsed second word for this dot expression
         SExpParseState::TermList(srcloc, Some(parsed), pp, list_content) => {
@@ -718,7 +718,7 @@ fn parse_sexp_step(loc: Srcloc, current_state: &SExpParseState, this_char: u8) -
                     SExpParseResult::Error(l, e) => SExpParseResult::Error(l, e),
                 },
             }
-        },
+        }
         // we are passing a dot-expression (x . y) and not in a comment and don't have an object already discovered
         SExpParseState::TermList(srcloc, None, pp, list_content) => {
             // pp is the inner parsestate inside the dot-expressions

--- a/src/compiler/sexp.rs
+++ b/src/compiler/sexp.rs
@@ -681,7 +681,7 @@ fn parse_sexp_step(loc: Srcloc, current_state: &SExpParseState, this_char: u8) -
                     let mut list_copy = list_content.to_vec();
                     match list_copy.pop() {
                         Some(v) => {
-                            let new_tail = make_cons(v, Rc::clone(&parsed));
+                            let new_tail = make_cons(v, Rc::clone(parsed));
                             if list_copy.is_empty() {
                                 emit(Rc::new(new_tail), SExpParseState::Empty)
                             } else {


### PR DESCRIPTION
This branch simplifies the parsing of termlist in pre-form assembling, and replaces calls to `.clone()` on Rc objects with the `Rc::clone()` call which is more memory efficient.