### PR TITLE
Use pypi trusted providers

### DIFF
--- a/.github/workflows/build-arm64-wheels.yml
+++ b/.github/workflows/build-arm64-wheels.yml
@@ -77,20 +77,14 @@ jobs:
       id: check_secrets
       shell: bash
       run: |
-        unset HAS_SECRET
         unset HAS_AWS_SECRET
-
-        if [ -n "$SECRET" ]; then HAS_SECRET='true' ; fi
-        echo HAS_SECRET=${HAS_SECRET} >>$GITHUB_OUTPUT
 
         if [ -n "$AWS_SECRET" ]; then HAS_AWS_SECRET='true' ; fi
         echo HAS_AWS_SECRET=${HAS_AWS_SECRET} >>$GITHUB_OUTPUT
       env:
-        SECRET: "${{ secrets.GITHUB_TOKEN }}"
         AWS_SECRET: "${{ secrets.CHIA_AWS_ACCOUNT_ID }}"
 
     - name: Set Env
-      if: steps.check_secrets.outputs.HAS_SECRET
       uses: Chia-Network/actions/setjobenv@main
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-arm64-wheels.yml
+++ b/.github/workflows/build-arm64-wheels.yml
@@ -65,7 +65,7 @@ jobs:
         name: wheels
         path: target/wheels/
 
-    - name: Install Twine
+    - name: Install job deps
       run: |
         if [ ! -f "venv" ]; then rm -rf venv; fi
         sudo apt install python3 python3-pip -y
@@ -73,7 +73,6 @@ jobs:
         if [ ! -f "activate" ]; then ln -s venv/bin/activate; fi
         . ./activate
         pip3 install setuptools_rust
-        pip3 install twine
     - name: Test for secrets access
       id: check_secrets
       shell: bash
@@ -82,35 +81,37 @@ jobs:
         unset HAS_AWS_SECRET
 
         if [ -n "$SECRET" ]; then HAS_SECRET='true' ; fi
-        echo "HAS_SECRET=${HAS_SECRET}" >>$GITHUB_OUTPUT
+        echo HAS_SECRET=${HAS_SECRET} >>$GITHUB_OUTPUT
 
         if [ -n "$AWS_SECRET" ]; then HAS_AWS_SECRET='true' ; fi
         echo HAS_AWS_SECRET=${HAS_AWS_SECRET} >>$GITHUB_OUTPUT
       env:
-        SECRET: "${{ secrets.test_pypi_password }}"
+        SECRET: "${{ secrets.GITHUB_TOKEN }}"
         AWS_SECRET: "${{ secrets.CHIA_AWS_ACCOUNT_ID }}"
 
-    - name: publish (PyPi)
-      if: startsWith(github.event.ref, 'refs/tags') && steps.check_secrets.outputs.HAS_SECRET
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_NON_INTERACTIVE: 1
-        TWINE_PASSWORD: ${{ secrets.pypi_password }}
-      run: |
-        . ./activate
-        twine upload --non-interactive --skip-existing --verbose 'target/wheels/*'
-    - name: publish (Test PyPi)
+    - name: Set Env
       if: steps.check_secrets.outputs.HAS_SECRET
+      uses: Chia-Network/actions/setjobenv@main
       env:
-        TWINE_REPOSITORY_URL: https://test.pypi.org/legacy/
-        TWINE_USERNAME: __token__
-        TWINE_NON_INTERACTIVE: 1
-        TWINE_PASSWORD: ${{ secrets.test_pypi_password }}
-      run: |
-        . ./activate
-        twine upload --non-interactive --skip-existing --verbose 'target/wheels/*'
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: publish (PyPi)
+      if: env.RELEASE == 'true'
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        packages-dir: target/wheels/
+        skip-existing: true
+
+    - name: publish (Test PyPi)
+      if: env.PRE_RELEASE == 'true'
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/
+        packages-dir: target/wheels/
+        skip-existing: true
 
     - name: Configure AWS credentials
+      if: steps.check_secrets.outputs.HAS_AWS_SECRET
       uses: aws-actions/configure-aws-credentials@v2
       with:
         role-to-assume: arn:aws:iam::${{ secrets.CHIA_AWS_ACCOUNT_ID }}:role/installer-upload

--- a/.github/workflows/build-m1-wheel.yml
+++ b/.github/workflows/build-m1-wheel.yml
@@ -115,20 +115,14 @@ jobs:
       id: check_secrets
       shell: bash
       run: |
-        unset HAS_SECRET
         unset HAS_AWS_SECRET
-
-        if [ -n "$SECRET" ]; then HAS_SECRET='true' ; fi
-        echo "HAS_SECRET=${HAS_SECRET}" >>$GITHUB_OUTPUT
 
         if [ -n "$AWS_SECRET" ]; then HAS_AWS_SECRET='true' ; fi
         echo HAS_AWS_SECRET=${HAS_AWS_SECRET} >>$GITHUB_OUTPUT
       env:
-        SECRET: "${{ secrets.GITHUB_TOKEN }}"
         AWS_SECRET: "${{ secrets.CHIA_AWS_ACCOUNT_ID }}"
 
     - name: Set Env
-      if: steps.check_secrets.outputs.HAS_SECRET
       uses: Chia-Network/actions/setjobenv@main
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-m1-wheel.yml
+++ b/.github/workflows/build-m1-wheel.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   build_wheels:
     name: Build wheel on Mac M1
-    runs-on: [m1]
+    runs-on: [MacOS, ARM64]
     strategy:
       fail-fast: false
 
@@ -49,43 +49,43 @@ jobs:
 
     - name: Build m1 wheels
       run: |
-        arch -arm64 python3 -m venv venv
+        python3 -m venv venv
         . ./venv/bin/activate
         export PATH=~/.cargo/bin:$PATH
-        arch -arm64 pip install maturin==1.1.0
-        arch -arm64 maturin build -i python --release --strip
-        arch -arm64 cargo test
+        pip install maturin==1.1.0
+        maturin build -i python --release --strip
+        cargo test
 
     - name: Install clvm_tools_rs wheel
       run: |
         . ./venv/bin/activate
         ls target/wheels/
-        arch -arm64 pip install ./target/wheels/clvm_tools_rs*.whl
+        pip install ./target/wheels/clvm_tools_rs*.whl
 
     - name: Install other wheels
       run: |
         . ./venv/bin/activate
-        arch -arm64 python -m pip install pytest
-        arch -arm64 python -m pip install blspy
+        python -m pip install pytest
+        python -m pip install blspy
 
     - name: install clvm & clvm_tools
       run: |
         . ./venv/bin/activate
-        arch -arm64 git clone https://github.com/Chia-Network/clvm.git --branch=main --single-branch
-        arch -arm64 python -m pip install ./clvm
-        arch -arm64 python -m pip install clvm_rs
+        git clone https://github.com/Chia-Network/clvm.git --branch=main --single-branch
+        python -m pip install ./clvm
+        python -m pip install clvm_rs
 
-        arch -arm64 git clone https://github.com/Chia-Network/clvm_tools.git --branch=main --single-branch
-        arch -arm64 python -m pip install ./clvm_tools
+        git clone https://github.com/Chia-Network/clvm_tools.git --branch=main --single-branch
+        python -m pip install ./clvm_tools
 
     - name: Ensure clvm, clvm_rs, clvm_tools are installed
       run: |
         . ./venv/bin/activate
-        arch -arm64 python -c 'import clvm'
-        arch -arm64 python -c 'import clvm; print(clvm.__file__)'
-        arch -arm64 python -c 'import clvm_rs; print(clvm_rs.__file__)'
-        arch -arm64 python -c 'import clvm_tools; print(clvm_tools.__file__)'
-        arch -arm64 python -c 'import clvm_tools_rs; print(clvm_tools_rs.__file__)'
+        python -c 'import clvm'
+        python -c 'import clvm; print(clvm.__file__)'
+        python -c 'import clvm_rs; print(clvm_rs.__file__)'
+        python -c 'import clvm_tools; print(clvm_tools.__file__)'
+        python -c 'import clvm_tools_rs; print(clvm_tools_rs.__file__)'
 
     - name: Install pytest
       run: |
@@ -97,13 +97,13 @@ jobs:
 #      run: |
 #        . ./venv/bin/activate
 #        cd clvm
-#        arch -arm64 python -m py.test tests
+#        python -m py.test tests
 
     - name: Run tests from clvm_tools
       run: |
         . ./venv/bin/activate
         cd clvm_tools
-        arch -arm64 pytest
+        pytest
 
     - name: Upload wheels
       uses: actions/upload-artifact@v3
@@ -124,30 +124,32 @@ jobs:
         if [ -n "$AWS_SECRET" ]; then HAS_AWS_SECRET='true' ; fi
         echo HAS_AWS_SECRET=${HAS_AWS_SECRET} >>$GITHUB_OUTPUT
       env:
-        SECRET: "${{ secrets.test_pypi_password }}"
+        SECRET: "${{ secrets.GITHUB_TOKEN }}"
         AWS_SECRET: "${{ secrets.CHIA_AWS_ACCOUNT_ID }}"
 
-    - name: Install twine
-      run: arch -arm64 pip install twine
-
-    - name: Publish distribution to PyPI
-      if: startsWith(github.event.ref, 'refs/tags') && steps.check_secrets.outputs.HAS_SECRET
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_NON_INTERACTIVE: 1
-        TWINE_PASSWORD: ${{ secrets.pypi_password }}
-      run: arch -arm64 twine upload --non-interactive --skip-existing --verbose 'target/wheels/*'
-
-    - name: Publish distribution to Test PyPI
+    - name: Set Env
       if: steps.check_secrets.outputs.HAS_SECRET
+      uses: Chia-Network/actions/setjobenv@main
       env:
-        TWINE_REPOSITORY_URL: https://test.pypi.org/legacy/
-        TWINE_USERNAME: __token__
-        TWINE_NON_INTERACTIVE: 1
-        TWINE_PASSWORD: ${{ secrets.test_pypi_password }}
-      run: arch -arm64 twine upload --non-interactive --skip-existing --verbose 'target/wheels/*'
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: publish (PyPi)
+      if: env.RELEASE == 'true'
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        packages-dir: target/wheels/
+        skip-existing: true
+
+    - name: publish (Test PyPi)
+      if: env.PRE_RELEASE == 'true'
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/
+        packages-dir: target/wheels/
+        skip-existing: true
 
     - name: Configure AWS credentials
+      if: steps.check_secrets.outputs.HAS_AWS_SECRET
       uses: aws-actions/configure-aws-credentials@v2
       with:
         role-to-assume: arn:aws:iam::${{ secrets.CHIA_AWS_ACCOUNT_ID }}:role/installer-upload

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -225,9 +225,6 @@ jobs:
         name: wheels
         path: ./target/wheels/
 
-    - name: Install Twine
-      run: pip install twine
-
     - name: Test for secrets access
       id: check_secrets
       shell: bash
@@ -241,27 +238,32 @@ jobs:
         if [ -n "$AWS_SECRET" ]; then HAS_AWS_SECRET='true' ; fi
         echo HAS_AWS_SECRET=${HAS_AWS_SECRET} >>$GITHUB_OUTPUT
       env:
-        SECRET: "${{ secrets.test_pypi_password }}"
+        SECRET: "${{ secrets.GITHUB_TOKEN }}"
         AWS_SECRET: "${{ secrets.CHIA_AWS_ACCOUNT_ID }}"
 
-    - name: publish (PyPi)
-      if: startsWith(github.event.ref, 'refs/tags') && steps.check_secrets.outputs.HAS_SECRET
+    - name: Set Env
+      if: steps.check_secrets.outputs.HAS_SECRET
+      uses: Chia-Network/actions/setjobenv@main
       env:
-        TWINE_USERNAME: __token__
-        TWINE_NON_INTERACTIVE: 1
-        TWINE_PASSWORD: ${{ secrets.pypi_password }}
-      run: twine upload --non-interactive --skip-existing --verbose 'target/wheels/*'
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: publish (PyPi)
+      if: env.RELEASE == 'true'
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        packages-dir: target/wheels/
+        skip-existing: true
 
     - name: publish (Test PyPi)
-      if: steps.check_secrets.outputs.HAS_SECRET
-      env:
-        TWINE_REPOSITORY_URL: https://test.pypi.org/legacy/
-        TWINE_USERNAME: __token__
-        TWINE_NON_INTERACTIVE: 1
-        TWINE_PASSWORD: ${{ secrets.test_pypi_password }}
-      run: twine upload --non-interactive --skip-existing --verbose 'target/wheels/*'
+      if: env.PRE_RELEASE == 'true'
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/
+        packages-dir: target/wheels/
+        skip-existing: true
 
     - name: Configure AWS credentials
+      if: steps.check_secrets.outputs.HAS_AWS_SECRET
       uses: aws-actions/configure-aws-credentials@v2
       with:
         role-to-assume: arn:aws:iam::${{ secrets.CHIA_AWS_ACCOUNT_ID }}:role/installer-upload

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -229,20 +229,14 @@ jobs:
       id: check_secrets
       shell: bash
       run: |
-        unset HAS_SECRET
         unset HAS_AWS_SECRET
-
-        if [ -n "$SECRET" ]; then HAS_SECRET='true' ; fi
-        echo "HAS_SECRET=${HAS_SECRET}" >>$GITHUB_OUTPUT
 
         if [ -n "$AWS_SECRET" ]; then HAS_AWS_SECRET='true' ; fi
         echo HAS_AWS_SECRET=${HAS_AWS_SECRET} >>$GITHUB_OUTPUT
       env:
-        SECRET: "${{ secrets.GITHUB_TOKEN }}"
         AWS_SECRET: "${{ secrets.CHIA_AWS_ACCOUNT_ID }}"
 
     - name: Set Env
-      if: steps.check_secrets.outputs.HAS_SECRET
       uses: Chia-Network/actions/setjobenv@main
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
With some additional housekeeping:

- arch -arm64 in m1 wheel job commands no longer required, this job originally ran on intel procs which did require this command prefix.
- Use more generic macos/arm64 runner tags in preparation for future M2 runners