### PR TITLE
20230827 cse fix undominated conditions

### DIFF
--- a/resources/tests/strict/cse-test-no-dom.clsp
+++ b/resources/tests/strict/cse-test-no-dom.clsp
@@ -1,0 +1,23 @@
+(mod (X)
+  (include *standard-cl-23*)
+
+  (defun S (C)
+    (if C
+      (assign-lambda 
+        Z (f (f C))
+        Y (r (f C))
+        R (r C)
+        (if (= Z 2)
+          (if (= 1 (f Y))
+            (r Y)
+            (S R)
+            )
+          (S R)
+          )
+        )
+        ()
+      )
+    )
+
+  (S X)
+  )

--- a/src/compiler/optimize/bodyform.rs
+++ b/src/compiler/optimize/bodyform.rs
@@ -9,7 +9,7 @@ use crate::compiler::comptypes::{Binding, BodyForm, CompileForm, LambdaData, Let
 
 /// A path in a bodyform.  Allows us to find and potentially replace the bodyform
 /// in a larger expression.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum BodyformPathArc {
     LetBinding(usize),   // In (let ((a 1) (b 2)) LetBinding(1) points to 2
     CallArgument(usize), // in (x0 x1 x2 x3 x4 x5) CallArgument(3) points to x3

--- a/src/compiler/optimize/cse.rs
+++ b/src/compiler/optimize/cse.rs
@@ -685,7 +685,7 @@ pub fn cse_optimize_bodyform(
     while !new_binding_stack.is_empty() {
         let (still_dominated, not_dominated): (
             CSEReplacementTargetAndBindings<'_>,
-            CSEReplacementTargetAndBindings<'_>
+            CSEReplacementTargetAndBindings<'_>,
         ) = new_binding_stack.iter().partition(|(t, _)| {
             new_binding_stack.iter().any(|(t_other, _)| {
                 // t is dominated if t_other contains it.

--- a/src/tests/compiler/optimizer/cse.rs
+++ b/src/tests/compiler/optimizer/cse.rs
@@ -98,9 +98,9 @@ fn test_cse_dominace_sorting() {
         "brun".to_string(),
         "-n".to_string(),
         program,
-        "(((3 3) (2 1 13 19) (5 5) (7 7)))".to_string()
+        "(((3 3) (2 1 13 19) (5 5) (7 7)))".to_string(),
     ])
-        .trim()
-        .to_string();
+    .trim()
+    .to_string();
     assert_eq!(run_result, "(13 19)");
 }

--- a/src/tests/compiler/optimizer/cse.rs
+++ b/src/tests/compiler/optimizer/cse.rs
@@ -84,3 +84,23 @@ fn test_cse_tricky_lambda() {
         .to_string();
     assert_eq!(run_result_5, "240");
 }
+
+// Ensure that we're sorting CSE rounds to apply by dominance so we do inner
+// replacements before outer ones.  Any that aren't dominated don't have an
+// order that matters.
+#[test]
+fn test_cse_dominace_sorting() {
+    let filename = "resources/tests/strict/cse-test-no-dom.clsp";
+    let program = do_basic_run(&vec!["run".to_string(), filename.to_string()])
+        .trim()
+        .to_string();
+    let run_result = do_basic_brun(&vec![
+        "brun".to_string(),
+        "-n".to_string(),
+        program,
+        "(((3 3) (2 1 13 19) (5 5) (7 7)))".to_string()
+    ])
+        .trim()
+        .to_string();
+    assert_eq!(run_result, "(13 19)");
+}


### PR DESCRIPTION
Make sure to sort CSE applications by dominance so that we apply them in reverse order, otherwise we can try to do a replacement downstream of one we've already done and not be able to find the target.